### PR TITLE
feat(auth): add FindByEmail method to CredentialRepository

### DIFF
--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -135,6 +135,16 @@ func (m *mockCredentialRepo) FindByProvider(_ context.Context, provider, provide
 	return cred, nil
 }
 
+func (m *mockCredentialRepo) FindByEmail(_ context.Context, email string) ([]*entities.Credential, error) {
+	var result []*entities.Credential
+	for _, cred := range m.credentials {
+		if cred.Email() == email {
+			result = append(result, cred)
+		}
+	}
+	return result, nil
+}
+
 func (m *mockCredentialRepo) FindByAgent(_ context.Context, _ string) ([]*entities.Credential, error) {
 	return nil, nil
 }

--- a/pkg/auth/domain/repositories/repositories.go
+++ b/pkg/auth/domain/repositories/repositories.go
@@ -86,6 +86,9 @@ type CredentialRepository interface {
 	// FindByProvider retrieves a Credential by provider and provider user ID.
 	FindByProvider(ctx context.Context, provider, providerUserID string) (*entities.Credential, error)
 
+	// FindByEmail retrieves all credentials associated with the given email address.
+	FindByEmail(ctx context.Context, email string) ([]*entities.Credential, error)
+
 	// FindByAgent retrieves all credentials for the given agent.
 	FindByAgent(ctx context.Context, agentID string) ([]*entities.Credential, error)
 

--- a/pkg/auth/infrastructure/database/gorm/repositories.go
+++ b/pkg/auth/infrastructure/database/gorm/repositories.go
@@ -116,6 +116,23 @@ func (r *credentialRepository) FindByProvider(ctx context.Context, provider, pro
 	return m.ToEntity()
 }
 
+func (r *credentialRepository) FindByEmail(ctx context.Context, email string) ([]*entities.Credential, error) {
+	var records []models.CredentialModel
+	if err := r.db.WithContext(ctx).Where("email = ?", email).Find(&records).Error; err != nil {
+		return nil, err
+	}
+
+	result := make([]*entities.Credential, 0, len(records))
+	for i := range records {
+		cred, err := records[i].ToEntity()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, cred)
+	}
+	return result, nil
+}
+
 func (r *credentialRepository) FindByAgent(ctx context.Context, agentID string) ([]*entities.Credential, error) {
 	var records []models.CredentialModel
 	if err := r.db.WithContext(ctx).Where("agent_id = ?", agentID).Find(&records).Error; err != nil {

--- a/pkg/auth/infrastructure/http/handlers_test.go
+++ b/pkg/auth/infrastructure/http/handlers_test.go
@@ -131,6 +131,9 @@ func (m *mockCredRepo) FindByID(_ context.Context, _ string) (*entities.Credenti
 func (m *mockCredRepo) FindByProvider(_ context.Context, _, _ string) (*entities.Credential, error) {
 	return nil, nil
 }
+func (m *mockCredRepo) FindByEmail(_ context.Context, _ string) ([]*entities.Credential, error) {
+	return nil, nil
+}
 func (m *mockCredRepo) FindByAgent(ctx context.Context, agentID string) ([]*entities.Credential, error) {
 	if m.findByAgentFunc != nil {
 		return m.findByAgentFunc(ctx, agentID)

--- a/pkg/auth/infrastructure/models/credential.go
+++ b/pkg/auth/infrastructure/models/credential.go
@@ -12,7 +12,7 @@ type CredentialModel struct {
 	AgentID        string `gorm:"not null;index"`
 	Provider       string `gorm:"not null;uniqueIndex:idx_provider_user"`
 	ProviderUserID string `gorm:"not null;uniqueIndex:idx_provider_user"`
-	Email          string
+	Email          string `gorm:"index:idx_email"`
 	DisplayName    string
 	Active         bool `gorm:"not null;default:true"`
 	CreatedAt      time.Time


### PR DESCRIPTION
Add FindByEmail lookup to support cross-provider deduplication during
OAuth authentication. This enables the bootstrap flow (Story 2) to find
existing credentials by email address when a user signs in with a
different provider.

- Add FindByEmail to CredentialRepository interface
- Add GORM implementation querying by email column
- Add database index on email column for query performance
- Update mock implementations in test files

https://claude.ai/code/session_019L68bpYKjVXJmTqgqEjt19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Interface expansion plus a database index/schema tag change can break existing implementations/migrations if not applied consistently, but the logic itself is a straightforward query addition.
> 
> **Overview**
> Adds `FindByEmail` to the `CredentialRepository` contract and wires it through the GORM implementation to return all credentials matching an email address.
> 
> Updates test mocks to satisfy the expanded interface, and adds an `idx_email` DB index on the `credentials.email` column to support efficient lookups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd7c6eb43d2e76cb1ae9a22dd572676069328bda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->