### PR TITLE
Add TransactionID to EventEnvelope for unit of work correlation

### DIFF
--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -27,3 +27,14 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 - Integration tests use `ghcr.io/goccy/bigquery-emulator` via testcontainers; skip gracefully without Docker
 - Added BigQuery variants to shared table-driven tests in `eventstore_test.go` and `eventstore_range_test.go`
 - **Why:** BigQuery is append-optimized and enables powerful analytics over event streams — natural fit for event sourcing at scale
+
+---
+
+### 2026-04-04: Transaction ID for unit of work correlation
+
+- Added `TransactionID` field to `EventEnvelope[T]` — a KSUID string that correlates all events committed in the same unit of work
+- `SimpleUnitOfWork.Commit()` generates a single transaction ID and stamps it on every event before persisting
+- Updated `ToAnyEnvelope` to copy the `TransactionID` field
+- Field is `omitempty` in JSON so existing events without a transaction ID remain backward-compatible
+- Added tests: same-commit events share a transaction ID, different commits get different IDs, dispatched events carry the transaction ID
+- **Why:** Enables correlating events across multiple aggregates that were committed together, useful for auditing, debugging, and cross-aggregate consistency tracking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: make test
       
       - name: Run linter
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v7
         if: matrix.go-version == '1.25'
         with:
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21, 1.22, 1.23]
+        go-version: ['1.25']
     
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +38,13 @@ jobs:
       
       - name: Run linter
         uses: golangci/golangci-lint-action@v4
-        if: matrix.go-version == '1.23'
+        if: matrix.go-version == '1.25'
         with:
           version: latest
       
       - name: Upload coverage
         uses: codecov/codecov-action@v4
-        if: matrix.go-version == '1.23'
+        if: matrix.go-version == '1.25'
         with:
           file: ./coverage.out
           flags: unittests
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       
       - name: Build
         run: make build

--- a/pkg/eventsourcing/application/unitofwork.go
+++ b/pkg/eventsourcing/application/unitofwork.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/segmentio/ksuid"
 )
 
 // UnitOfWork is an interface for managing transactions across multiple entities.
@@ -120,6 +121,18 @@ func (uow *SimpleUnitOfWork) Commit(ctx context.Context) error {
 		uow.expectedVersions = make(map[string]int)
 		uow.mu.Unlock()
 		return nil
+	}
+
+	// Stamp all events with the same transaction ID to correlate events in this unit of work
+	transactionID := ksuid.New().String()
+	for aggregateID, events := range eventsByAggregate {
+		for i := range events {
+			events[i].TransactionID = transactionID
+		}
+		eventsByAggregate[aggregateID] = events
+	}
+	for i := range allEvents {
+		allEvents[i].TransactionID = transactionID
 	}
 
 	// Store references before unlocking

--- a/pkg/eventsourcing/application/unitofwork.go
+++ b/pkg/eventsourcing/application/unitofwork.go
@@ -105,13 +105,11 @@ func (uow *SimpleUnitOfWork) Commit(ctx context.Context) error {
 
 	// Collect all uncommitted events from all tracked entities
 	eventsByAggregate := make(map[string][]domain.EventEnvelope[any])
-	var allEvents []domain.EventEnvelope[any]
 
 	for aggregateID, entity := range uow.entities {
 		uncommitted := entity.GetUncommittedEvents()
 		if len(uncommitted) > 0 {
 			eventsByAggregate[aggregateID] = uncommitted
-			allEvents = append(allEvents, uncommitted...)
 		}
 	}
 
@@ -123,16 +121,14 @@ func (uow *SimpleUnitOfWork) Commit(ctx context.Context) error {
 		return nil
 	}
 
-	// Stamp all events with the same transaction ID to correlate events in this unit of work
+	// Stamp all events with the same transaction ID, then build allEvents from the stamped slices
 	transactionID := ksuid.New().String()
-	for aggregateID, events := range eventsByAggregate {
+	var allEvents []domain.EventEnvelope[any]
+	for _, events := range eventsByAggregate {
 		for i := range events {
 			events[i].TransactionID = transactionID
 		}
-		eventsByAggregate[aggregateID] = events
-	}
-	for i := range allEvents {
-		allEvents[i].TransactionID = transactionID
+		allEvents = append(allEvents, events...)
 	}
 
 	// Store references before unlocking

--- a/pkg/eventsourcing/application/unitofwork_test.go
+++ b/pkg/eventsourcing/application/unitofwork_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/ddd"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
@@ -312,9 +311,6 @@ func TestCommit(t *testing.T) {
 		if err := uow.Commit(ctx); err != nil {
 			t.Fatalf("Commit failed: %v", err)
 		}
-
-		// Give dispatcher time to process (since it's async)
-		time.Sleep(10 * time.Millisecond)
 
 		if callCount != 1 {
 			t.Errorf("Expected handler to be called once, got %d", callCount)
@@ -794,9 +790,6 @@ func TestCommit_TransactionID(t *testing.T) {
 		if err := uow.Commit(ctx); err != nil {
 			t.Fatalf("Commit failed: %v", err)
 		}
-
-		// Give dispatcher time to process
-		time.Sleep(10 * time.Millisecond)
 
 		if dispatchedTxID == "" {
 			t.Error("Expected dispatched event to have a TransactionID")

--- a/pkg/eventsourcing/application/unitofwork_test.go
+++ b/pkg/eventsourcing/application/unitofwork_test.go
@@ -641,6 +641,175 @@ func TestCommit_RecordBeforeTrack(t *testing.T) {
 	})
 }
 
+func TestCommit_TransactionID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single entity events share same transaction ID", func(t *testing.T) {
+		t.Parallel()
+		eventStore := infrastructure.NewMemoryStore()
+		uow := application.NewSimpleUnitOfWork(eventStore, nil)
+
+		entity := NewTestEntity("entity-1", "Test", "test@example.com")
+		if err := uow.Track(entity); err != nil {
+			t.Fatalf("Failed to track entity: %v", err)
+		}
+
+		if err := entity.RecordEvent(map[string]string{"name": "Test"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+		if err := entity.RecordEvent(map[string]string{"name": "Updated"}, "test.updated"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+
+		ctx := context.Background()
+		if err := uow.Commit(ctx); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+
+		events, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("Expected 2 events, got %d", len(events))
+		}
+
+		if events[0].TransactionID == "" {
+			t.Error("Expected non-empty TransactionID on first event")
+		}
+		if events[0].TransactionID != events[1].TransactionID {
+			t.Errorf("Expected same TransactionID on both events, got %q and %q",
+				events[0].TransactionID, events[1].TransactionID)
+		}
+	})
+
+	t.Run("multiple entities share same transaction ID", func(t *testing.T) {
+		t.Parallel()
+		eventStore := infrastructure.NewMemoryStore()
+		uow := application.NewSimpleUnitOfWork(eventStore, nil)
+
+		entity1 := NewTestEntity("entity-1", "Test1", "test1@example.com")
+		entity2 := NewTestEntity("entity-2", "Test2", "test2@example.com")
+
+		if err := uow.Track(entity1, entity2); err != nil {
+			t.Fatalf("Failed to track entities: %v", err)
+		}
+
+		if err := entity1.RecordEvent(map[string]string{"name": "Test1"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+		if err := entity2.RecordEvent(map[string]string{"name": "Test2"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+
+		ctx := context.Background()
+		if err := uow.Commit(ctx); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+
+		events1, _ := eventStore.GetEvents(ctx, "entity-1")
+		events2, _ := eventStore.GetEvents(ctx, "entity-2")
+
+		if len(events1) != 1 || len(events2) != 1 {
+			t.Fatalf("Expected 1 event each, got %d and %d", len(events1), len(events2))
+		}
+
+		if events1[0].TransactionID == "" {
+			t.Error("Expected non-empty TransactionID")
+		}
+		if events1[0].TransactionID != events2[0].TransactionID {
+			t.Errorf("Expected same TransactionID across aggregates, got %q and %q",
+				events1[0].TransactionID, events2[0].TransactionID)
+		}
+	})
+
+	t.Run("different commits have different transaction IDs", func(t *testing.T) {
+		t.Parallel()
+		eventStore := infrastructure.NewMemoryStore()
+
+		// First commit
+		uow1 := application.NewSimpleUnitOfWork(eventStore, nil)
+		entity1 := NewTestEntity("entity-1", "Test", "test@example.com")
+		if err := uow1.Track(entity1); err != nil {
+			t.Fatalf("Failed to track: %v", err)
+		}
+		if err := entity1.RecordEvent(map[string]string{"name": "Test"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+
+		ctx := context.Background()
+		if err := uow1.Commit(ctx); err != nil {
+			t.Fatalf("First commit failed: %v", err)
+		}
+
+		events1, _ := eventStore.GetEvents(ctx, "entity-1")
+		txID1 := events1[0].TransactionID
+
+		// Second commit on a different aggregate
+		uow2 := application.NewSimpleUnitOfWork(eventStore, nil)
+		entity2 := NewTestEntity("entity-2", "Test2", "test2@example.com")
+		if err := uow2.Track(entity2); err != nil {
+			t.Fatalf("Failed to track: %v", err)
+		}
+		if err := entity2.RecordEvent(map[string]string{"name": "Test2"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+		if err := uow2.Commit(ctx); err != nil {
+			t.Fatalf("Second commit failed: %v", err)
+		}
+
+		events2, _ := eventStore.GetEvents(ctx, "entity-2")
+		txID2 := events2[0].TransactionID
+
+		if txID1 == txID2 {
+			t.Errorf("Expected different TransactionIDs for different commits, both got %q", txID1)
+		}
+	})
+
+	t.Run("transaction ID is dispatched with events", func(t *testing.T) {
+		t.Parallel()
+		eventStore := infrastructure.NewMemoryStore()
+		dispatcher := domain.NewEventDispatcher()
+
+		var dispatchedTxID string
+		handler := func(ctx context.Context, env domain.EventEnvelope[map[string]string]) error {
+			dispatchedTxID = env.TransactionID
+			return nil
+		}
+
+		if err := domain.Subscribe[map[string]string](dispatcher, "test.created", handler); err != nil {
+			t.Fatalf("Failed to subscribe: %v", err)
+		}
+
+		uow := application.NewSimpleUnitOfWork(eventStore, dispatcher)
+		entity := NewTestEntity("entity-1", "Test", "test@example.com")
+		if err := uow.Track(entity); err != nil {
+			t.Fatalf("Failed to track: %v", err)
+		}
+		if err := entity.RecordEvent(map[string]string{"name": "Test"}, "test.created"); err != nil {
+			t.Fatalf("Failed to record event: %v", err)
+		}
+
+		ctx := context.Background()
+		if err := uow.Commit(ctx); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+
+		// Give dispatcher time to process
+		time.Sleep(10 * time.Millisecond)
+
+		if dispatchedTxID == "" {
+			t.Error("Expected dispatched event to have a TransactionID")
+		}
+
+		events, _ := eventStore.GetEvents(ctx, "entity-1")
+		if dispatchedTxID != events[0].TransactionID {
+			t.Errorf("Expected dispatched TransactionID %q to match stored %q",
+				dispatchedTxID, events[0].TransactionID)
+		}
+	})
+}
+
 // failingEventStore is a test helper that fails on Append
 type failingEventStore struct {
 	*infrastructure.MemoryStore

--- a/pkg/eventsourcing/application/unitofwork_test.go
+++ b/pkg/eventsourcing/application/unitofwork_test.go
@@ -238,9 +238,18 @@ func TestCommit(t *testing.T) {
 		}
 
 		// Verify all events were persisted
-		events1, _ := eventStore.GetEvents(ctx, "entity-1")
-		events2, _ := eventStore.GetEvents(ctx, "entity-2")
-		events3, _ := eventStore.GetEvents(ctx, "entity-3")
+		events1, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-1: %v", err)
+		}
+		events2, err := eventStore.GetEvents(ctx, "entity-2")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-2: %v", err)
+		}
+		events3, err := eventStore.GetEvents(ctx, "entity-3")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-3: %v", err)
+		}
 
 		if len(events1) != 1 {
 			t.Errorf("Expected 1 event for entity1, got %d", len(events1))
@@ -381,7 +390,10 @@ func TestCommitFailure(t *testing.T) {
 		}
 
 		// Verify event was not persisted
-		events, _ := eventStore.GetEvents(ctx, "entity-1")
+		events, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events: %v", err)
+		}
 		if len(events) != 0 {
 			t.Errorf("Expected 0 events after failed commit, got %d", len(events))
 		}
@@ -703,8 +715,14 @@ func TestCommit_TransactionID(t *testing.T) {
 			t.Fatalf("Commit failed: %v", err)
 		}
 
-		events1, _ := eventStore.GetEvents(ctx, "entity-1")
-		events2, _ := eventStore.GetEvents(ctx, "entity-2")
+		events1, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-1: %v", err)
+		}
+		events2, err := eventStore.GetEvents(ctx, "entity-2")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-2: %v", err)
+		}
 
 		if len(events1) != 1 || len(events2) != 1 {
 			t.Fatalf("Expected 1 event each, got %d and %d", len(events1), len(events2))
@@ -738,7 +756,10 @@ func TestCommit_TransactionID(t *testing.T) {
 			t.Fatalf("First commit failed: %v", err)
 		}
 
-		events1, _ := eventStore.GetEvents(ctx, "entity-1")
+		events1, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-1: %v", err)
+		}
 		txID1 := events1[0].TransactionID
 
 		// Second commit on a different aggregate
@@ -754,7 +775,10 @@ func TestCommit_TransactionID(t *testing.T) {
 			t.Fatalf("Second commit failed: %v", err)
 		}
 
-		events2, _ := eventStore.GetEvents(ctx, "entity-2")
+		events2, err := eventStore.GetEvents(ctx, "entity-2")
+		if err != nil {
+			t.Fatalf("Failed to get events for entity-2: %v", err)
+		}
 		txID2 := events2[0].TransactionID
 
 		if txID1 == txID2 {
@@ -795,7 +819,10 @@ func TestCommit_TransactionID(t *testing.T) {
 			t.Error("Expected dispatched event to have a TransactionID")
 		}
 
-		events, _ := eventStore.GetEvents(ctx, "entity-1")
+		events, err := eventStore.GetEvents(ctx, "entity-1")
+		if err != nil {
+			t.Fatalf("Failed to get events: %v", err)
+		}
 		if dispatchedTxID != events[0].TransactionID {
 			t.Errorf("Expected dispatched TransactionID %q to match stored %q",
 				dispatchedTxID, events[0].TransactionID)

--- a/pkg/eventsourcing/domain/dispatcher.go
+++ b/pkg/eventsourcing/domain/dispatcher.go
@@ -61,13 +61,14 @@ func Subscribe[T any](d *EventDispatcher, eventType string, handler EventHandler
 
 		// Reconstruct EventEnvelope[T] with the typed payload
 		typedEnv := EventEnvelope[T]{
-			ID:          env.ID,
-			AggregateID: env.AggregateID,
-			EventType:   env.EventType,
-			Payload:     payload,
-			Created:     env.Created,
-			SequenceNo:  env.SequenceNo,
-			Metadata:    env.Metadata,
+			ID:            env.ID,
+			AggregateID:   env.AggregateID,
+			EventType:     env.EventType,
+			Payload:       payload,
+			Created:       env.Created,
+			SequenceNo:    env.SequenceNo,
+			TransactionID: env.TransactionID,
+			Metadata:      env.Metadata,
 		}
 
 		// Call the typed handler
@@ -279,13 +280,14 @@ func (d *EventDispatcher) UnmarshalEvent(ctx context.Context, data []byte, event
 
 	// Unmarshal the JSON into a temporary struct to extract metadata
 	var temp struct {
-		ID          string                 `json:"id"`
-		AggregateID string                 `json:"aggregate_id"`
-		EventType   string                 `json:"event_type"`
-		Payload     json.RawMessage        `json:"payload"`
-		Created     string                 `json:"timestamp"`
-		SequenceNo  int                    `json:"sequence_no"`
-		Metadata    map[string]interface{} `json:"metadata,omitempty"`
+		ID            string                 `json:"id"`
+		AggregateID   string                 `json:"aggregate_id"`
+		EventType     string                 `json:"event_type"`
+		Payload       json.RawMessage        `json:"payload"`
+		Created       string                 `json:"timestamp"`
+		SequenceNo    int                    `json:"sequence_no"`
+		TransactionID string                 `json:"transaction_id,omitempty"`
+		Metadata      map[string]interface{} `json:"metadata,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -305,13 +307,14 @@ func (d *EventDispatcher) UnmarshalEvent(ctx context.Context, data []byte, event
 
 	// Reconstruct EventEnvelope[any]
 	envelope := EventEnvelope[any]{
-		ID:          temp.ID,
-		AggregateID: temp.AggregateID,
-		EventType:   temp.EventType,
-		Payload:     payload,
-		Created:     created,
-		SequenceNo:  temp.SequenceNo,
-		Metadata:    temp.Metadata,
+		ID:            temp.ID,
+		AggregateID:   temp.AggregateID,
+		EventType:     temp.EventType,
+		Payload:       payload,
+		Created:       created,
+		SequenceNo:    temp.SequenceNo,
+		TransactionID: temp.TransactionID,
+		Metadata:      temp.Metadata,
 	}
 
 	return envelope, nil

--- a/pkg/eventsourcing/domain/event.go
+++ b/pkg/eventsourcing/domain/event.go
@@ -18,13 +18,14 @@ type Event interface {
 // for transport and persistence. The type parameter T represents the strongly-typed
 // event payload.
 type EventEnvelope[T any] struct {
-	ID          string                 `json:"id"`
-	AggregateID string                 `json:"aggregate_id"`
-	EventType   string                 `json:"event_type"`
-	Payload     T                      `json:"payload"`
-	Created     time.Time              `json:"timestamp"`
-	SequenceNo  int                    `json:"sequence_no"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	ID            string                 `json:"id"`
+	AggregateID   string                 `json:"aggregate_id"`
+	EventType     string                 `json:"event_type"`
+	Payload       T                      `json:"payload"`
+	Created       time.Time              `json:"timestamp"`
+	SequenceNo    int                    `json:"sequence_no"`
+	TransactionID string                 `json:"transaction_id,omitempty"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // NewEventEnvelope creates a new EventEnvelope with the given payload and metadata.

--- a/pkg/eventsourcing/domain/eventstore.go
+++ b/pkg/eventsourcing/domain/eventstore.go
@@ -55,12 +55,13 @@ type EventStore interface {
 // This allows storing events with different payload types together in the event store.
 func ToAnyEnvelope[T any](envelope EventEnvelope[T]) EventEnvelope[any] {
 	return EventEnvelope[any]{
-		ID:          envelope.ID,
-		AggregateID: envelope.AggregateID,
-		EventType:   envelope.EventType,
-		Payload:     envelope.Payload,
-		Created:     envelope.Created,
-		SequenceNo:  envelope.SequenceNo,
-		Metadata:    envelope.Metadata,
+		ID:            envelope.ID,
+		AggregateID:   envelope.AggregateID,
+		EventType:     envelope.EventType,
+		Payload:       envelope.Payload,
+		Created:       envelope.Created,
+		SequenceNo:    envelope.SequenceNo,
+		TransactionID: envelope.TransactionID,
+		Metadata:      envelope.Metadata,
 	}
 }

--- a/pkg/eventsourcing/infrastructure/bigquery_store.go
+++ b/pkg/eventsourcing/infrastructure/bigquery_store.go
@@ -168,25 +168,27 @@ func (s *BigQueryEventStore) buildInsertQuery(events []domain.EventEnvelope[any]
 		aggParam := fmt.Sprintf("agg_%d", i)
 		typeParam := fmt.Sprintf("type_%d", i)
 		seqParam := fmt.Sprintf("seq_%d", i)
+		txParam := fmt.Sprintf("tx_%d", i)
 		payParam := fmt.Sprintf("pay_%d", i)
 		metaParam := fmt.Sprintf("meta_%d", i)
 		tsParam := fmt.Sprintf("ts_%d", i)
 
-		valuePlaceholders = append(valuePlaceholders, fmt.Sprintf("(@%s, @%s, @%s, @%s, PARSE_JSON(@%s), PARSE_JSON(@%s), @%s)",
-			idParam, aggParam, typeParam, seqParam, payParam, metaParam, tsParam))
+		valuePlaceholders = append(valuePlaceholders, fmt.Sprintf("(@%s, @%s, @%s, @%s, @%s, PARSE_JSON(@%s), PARSE_JSON(@%s), @%s)",
+			idParam, aggParam, typeParam, seqParam, txParam, payParam, metaParam, tsParam))
 
 		params = append(params,
 			bigquery.QueryParameter{Name: idParam, Value: event.ID},
 			bigquery.QueryParameter{Name: aggParam, Value: event.AggregateID},
 			bigquery.QueryParameter{Name: typeParam, Value: event.EventType},
 			bigquery.QueryParameter{Name: seqParam, Value: event.SequenceNo},
+			bigquery.QueryParameter{Name: txParam, Value: event.TransactionID},
 			bigquery.QueryParameter{Name: payParam, Value: payloadJSON},
 			bigquery.QueryParameter{Name: metaParam, Value: metadataJSON},
 			bigquery.QueryParameter{Name: tsParam, Value: event.Created.UTC()},
 		)
 	}
 
-	querySQL := fmt.Sprintf("INSERT INTO %s (id, aggregate_id, event_type, sequence_no, payload, metadata, created_at) VALUES %s",
+	querySQL := fmt.Sprintf("INSERT INTO %s (id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at) VALUES %s",
 		s.fullTableID(), strings.Join(valuePlaceholders, ", "))
 
 	return querySQL, params, nil
@@ -194,7 +196,7 @@ func (s *BigQueryEventStore) buildInsertQuery(events []domain.EventEnvelope[any]
 
 // GetEvents retrieves all events for the given aggregate ID.
 func (s *BigQueryEventStore) GetEvents(ctx context.Context, aggregateID string) ([]domain.EventEnvelope[any], error) {
-	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg ORDER BY sequence_no ASC",
+	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg ORDER BY sequence_no ASC",
 		s.fullTableID())
 
 	q := s.client.Query(query)
@@ -207,7 +209,7 @@ func (s *BigQueryEventStore) GetEvents(ctx context.Context, aggregateID string) 
 
 // GetEventsFromVersion retrieves events starting from the specified version.
 func (s *BigQueryEventStore) GetEventsFromVersion(ctx context.Context, aggregateID string, fromVersion int) ([]domain.EventEnvelope[any], error) {
-	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg AND sequence_no >= @from_ver ORDER BY sequence_no ASC",
+	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg AND sequence_no >= @from_ver ORDER BY sequence_no ASC",
 		s.fullTableID())
 
 	q := s.client.Query(query)
@@ -230,7 +232,7 @@ func (s *BigQueryEventStore) GetEventsRange(ctx context.Context, aggregateID str
 		return s.GetEventsFromVersion(ctx, aggregateID, fromVersion)
 	}
 
-	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg AND sequence_no >= @from_ver AND sequence_no <= @to_ver ORDER BY sequence_no ASC",
+	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at FROM %s WHERE aggregate_id = @agg AND sequence_no >= @from_ver AND sequence_no <= @to_ver ORDER BY sequence_no ASC",
 		s.fullTableID())
 
 	q := s.client.Query(query)
@@ -246,7 +248,7 @@ func (s *BigQueryEventStore) GetEventsRange(ctx context.Context, aggregateID str
 // GetEventByID retrieves a specific event by its ID.
 // Note: This performs a full table scan since id is not in the clustering key.
 func (s *BigQueryEventStore) GetEventByID(ctx context.Context, eventID string) (domain.EventEnvelope[any], error) {
-	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, payload, metadata, created_at FROM %s WHERE id = @event_id LIMIT 1",
+	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at FROM %s WHERE id = @event_id LIMIT 1",
 		s.fullTableID())
 
 	q := s.client.Query(query)
@@ -339,13 +341,14 @@ func (s *BigQueryEventStore) queryEnvelopes(ctx context.Context, q *bigquery.Que
 // bigqueryEventRow is the persistence-layer DTO for BigQuery rows.
 // Fields must stay in sync with the BigQuery table schema.
 type bigqueryEventRow struct {
-	ID          string    `bigquery:"id"`
-	AggregateID string    `bigquery:"aggregate_id"`
-	EventType   string    `bigquery:"event_type"`
-	SequenceNo  int64     `bigquery:"sequence_no"`
-	Payload     string    `bigquery:"payload"`
-	Metadata    string    `bigquery:"metadata"`
-	CreatedAt   time.Time `bigquery:"created_at"`
+	ID            string    `bigquery:"id"`
+	AggregateID   string    `bigquery:"aggregate_id"`
+	EventType     string    `bigquery:"event_type"`
+	SequenceNo    int64     `bigquery:"sequence_no"`
+	TransactionID string    `bigquery:"transaction_id"`
+	Payload       string    `bigquery:"payload"`
+	Metadata      string    `bigquery:"metadata"`
+	CreatedAt     time.Time `bigquery:"created_at"`
 }
 
 func marshalPayloadAndMetadata(env domain.EventEnvelope[any]) (string, string, error) {
@@ -389,12 +392,13 @@ func bigqueryRowToEnvelope(row bigqueryEventRow) (domain.EventEnvelope[any], err
 	}
 
 	return domain.EventEnvelope[any]{
-		ID:          row.ID,
-		AggregateID: row.AggregateID,
-		EventType:   row.EventType,
-		Payload:     map[string]any(payload),
-		Created:     row.CreatedAt,
-		SequenceNo:  int(row.SequenceNo),
-		Metadata:    metadata,
+		ID:            row.ID,
+		AggregateID:   row.AggregateID,
+		EventType:     row.EventType,
+		Payload:       map[string]any(payload),
+		Created:       row.CreatedAt,
+		SequenceNo:    int(row.SequenceNo),
+		TransactionID: row.TransactionID,
+		Metadata:      metadata,
 	}, nil
 }

--- a/pkg/eventsourcing/infrastructure/bigquery_store.go
+++ b/pkg/eventsourcing/infrastructure/bigquery_store.go
@@ -145,12 +145,13 @@ func (s *BigQueryEventStore) buildInsertQuery(events []domain.EventEnvelope[any]
 		valuePlaceholders = append(valuePlaceholders, fmt.Sprintf("(@%s, @%s, @%s, @%s, @%s, @%s, @%s, @%s)",
 			idParam, aggParam, typeParam, seqParam, txParam, payParam, metaParam, tsParam))
 
+		txValue := bigquery.NullString{StringVal: event.TransactionID, Valid: event.TransactionID != ""}
 		params = append(params,
 			bigquery.QueryParameter{Name: idParam, Value: event.ID},
 			bigquery.QueryParameter{Name: aggParam, Value: event.AggregateID},
 			bigquery.QueryParameter{Name: typeParam, Value: event.EventType},
 			bigquery.QueryParameter{Name: seqParam, Value: event.SequenceNo},
-			bigquery.QueryParameter{Name: txParam, Value: event.TransactionID},
+			bigquery.QueryParameter{Name: txParam, Value: txValue},
 			bigquery.QueryParameter{Name: payParam, Value: payloadJSON},
 			bigquery.QueryParameter{Name: metaParam, Value: metadataJSON},
 			bigquery.QueryParameter{Name: tsParam, Value: event.Created.UTC()},
@@ -309,15 +310,17 @@ func (s *BigQueryEventStore) queryEnvelopes(ctx context.Context, q *bigquery.Que
 
 // bigqueryEventRow is the persistence-layer DTO for BigQuery rows.
 // Fields must stay in sync with the BigQuery table schema.
+// TransactionID uses bigquery.NullString so that existing rows with NULL
+// transaction_id decode without error.
 type bigqueryEventRow struct {
-	ID            string    `bigquery:"id"`
-	AggregateID   string    `bigquery:"aggregate_id"`
-	EventType     string    `bigquery:"event_type"`
-	SequenceNo    int64     `bigquery:"sequence_no"`
-	TransactionID string    `bigquery:"transaction_id"`
-	Payload       string    `bigquery:"payload"`
-	Metadata      string    `bigquery:"metadata"`
-	CreatedAt     time.Time `bigquery:"created_at"`
+	ID            string              `bigquery:"id"`
+	AggregateID   string              `bigquery:"aggregate_id"`
+	EventType     string              `bigquery:"event_type"`
+	SequenceNo    int64               `bigquery:"sequence_no"`
+	TransactionID bigquery.NullString `bigquery:"transaction_id"`
+	Payload       string              `bigquery:"payload"`
+	Metadata      string              `bigquery:"metadata"`
+	CreatedAt     time.Time           `bigquery:"created_at"`
 }
 
 func marshalPayloadAndMetadata(env domain.EventEnvelope[any]) (string, string, error) {
@@ -360,6 +363,11 @@ func bigqueryRowToEnvelope(row bigqueryEventRow) (domain.EventEnvelope[any], err
 		metadata = make(map[string]any)
 	}
 
+	txID := ""
+	if row.TransactionID.Valid {
+		txID = row.TransactionID.StringVal
+	}
+
 	return domain.EventEnvelope[any]{
 		ID:            row.ID,
 		AggregateID:   row.AggregateID,
@@ -367,7 +375,7 @@ func bigqueryRowToEnvelope(row bigqueryEventRow) (domain.EventEnvelope[any], err
 		Payload:       map[string]any(payload),
 		Created:       row.CreatedAt,
 		SequenceNo:    int(row.SequenceNo),
-		TransactionID: row.TransactionID,
+		TransactionID: txID,
 		Metadata:      metadata,
 	}, nil
 }

--- a/pkg/eventsourcing/infrastructure/bigquery_store_test.go
+++ b/pkg/eventsourcing/infrastructure/bigquery_store_test.go
@@ -100,6 +100,7 @@ func createBigQueryTable(t *testing.T, client *bigquery.Client, tableID string) 
 		{Name: "aggregate_id", Type: bigquery.StringFieldType, Required: true},
 		{Name: "event_type", Type: bigquery.StringFieldType, Required: true},
 		{Name: "sequence_no", Type: bigquery.IntegerFieldType, Required: true},
+		{Name: "transaction_id", Type: bigquery.StringFieldType},
 		{Name: "payload", Type: bigquery.StringFieldType, Required: true},
 		{Name: "metadata", Type: bigquery.StringFieldType},
 		{Name: "created_at", Type: bigquery.TimestampFieldType, Required: true},

--- a/pkg/eventsourcing/infrastructure/dynamo_store.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store.go
@@ -337,6 +337,10 @@ func envelopeToDynamoItem(env domain.EventEnvelope[any]) (map[string]types.Attri
 		"created_at":   &types.AttributeValueMemberS{Value: env.Created.UTC().Format(dynamoTimeFormat)},
 	}
 
+	if env.TransactionID != "" {
+		item["transaction_id"] = &types.AttributeValueMemberS{Value: env.TransactionID}
+	}
+
 	return item, nil
 }
 
@@ -390,14 +394,21 @@ func dynamoItemToEnvelope(item map[string]types.AttributeValue) (domain.EventEnv
 		metadata = make(map[string]any)
 	}
 
+	var transactionID string
+	if txAV, ok := item["transaction_id"]; ok {
+		if err := attributevalue.Unmarshal(txAV, &transactionID); err != nil {
+			return domain.EventEnvelope[any]{}, fmt.Errorf("failed to unmarshal transaction_id: %w", err)
+		}
+	}
+
 	return domain.EventEnvelope[any]{
-		ID:          id,
-		AggregateID: aggregateID,
-		EventType:   eventType,
-		Payload:     map[string]any(payload),
-		Created:     created,
-		SequenceNo:  sequenceNo,
-		Metadata:    metadata,
+		ID:            id,
+		AggregateID:   aggregateID,
+		EventType:     eventType,
+		Payload:       map[string]any(payload),
+		Created:       created,
+		SequenceNo:    sequenceNo,
+		TransactionID: transactionID,
+		Metadata:      metadata,
 	}, nil
 }
-

--- a/pkg/eventsourcing/infrastructure/dynamo_store_test.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store_test.go
@@ -70,6 +70,27 @@ func startDynamoContainer(t *testing.T) (string, error) {
 		}
 
 		dynamoEndpoint = fmt.Sprintf("http://%s:%s", host, port.Port())
+
+		// Probe DynamoDB readiness — the TCP port may be open before the
+		// service is ready to accept API calls, which causes "use of closed
+		// network connection" errors on the first real request.
+		probeClient := dynamodb.New(dynamodb.Options{
+			Region:       "us-east-1",
+			BaseEndpoint: &dynamoEndpoint,
+			Credentials:  credentials.NewStaticCredentialsProvider("dummy", "dummy", "dummy"),
+		})
+		for i := 0; i < 10; i++ {
+			_, err := probeClient.ListTables(ctx, &dynamodb.ListTablesInput{})
+			if err == nil {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+			if i == 9 {
+				dynamoSetupErr = fmt.Errorf("DynamoDB not ready after probing: %w", err)
+				_ = container.Terminate(ctx)
+				return
+			}
+		}
 	})
 
 	return dynamoEndpoint, dynamoSetupErr

--- a/pkg/eventsourcing/infrastructure/gorm_model.go
+++ b/pkg/eventsourcing/infrastructure/gorm_model.go
@@ -40,13 +40,14 @@ func (j *JSONB) Scan(value any) error {
 
 // GormEventModel is the GORM model for persisting events.
 type GormEventModel struct {
-	ID          string    `gorm:"primaryKey;column:id"`
-	AggregateID string    `gorm:"column:aggregate_id;index;uniqueIndex:idx_aggregate_sequence"`
-	EventType   string    `gorm:"column:event_type"`
-	SequenceNo  int       `gorm:"column:sequence_no;uniqueIndex:idx_aggregate_sequence"`
-	Payload     JSONB     `gorm:"column:payload;type:jsonb"`
-	Metadata    JSONB     `gorm:"column:metadata;type:jsonb"`
-	CreatedAt   time.Time `gorm:"column:created_at"`
+	ID            string    `gorm:"primaryKey;column:id"`
+	AggregateID   string    `gorm:"column:aggregate_id;index;uniqueIndex:idx_aggregate_sequence"`
+	EventType     string    `gorm:"column:event_type"`
+	SequenceNo    int       `gorm:"column:sequence_no;uniqueIndex:idx_aggregate_sequence"`
+	TransactionID string    `gorm:"column:transaction_id;index"`
+	Payload       JSONB     `gorm:"column:payload;type:jsonb"`
+	Metadata      JSONB     `gorm:"column:metadata;type:jsonb"`
+	CreatedAt     time.Time `gorm:"column:created_at"`
 }
 
 // TableName returns the table name for the event model.

--- a/pkg/eventsourcing/infrastructure/gorm_store.go
+++ b/pkg/eventsourcing/infrastructure/gorm_store.go
@@ -146,13 +146,14 @@ func envelopeToModel(env domain.EventEnvelope[any]) (GormEventModel, error) {
 	}
 
 	return GormEventModel{
-		ID:          env.ID,
-		AggregateID: env.AggregateID,
-		EventType:   env.EventType,
-		SequenceNo:  env.SequenceNo,
-		Payload:     payload,
-		Metadata:    metadata,
-		CreatedAt:   env.Created,
+		ID:            env.ID,
+		AggregateID:   env.AggregateID,
+		EventType:     env.EventType,
+		SequenceNo:    env.SequenceNo,
+		TransactionID: env.TransactionID,
+		Payload:       payload,
+		Metadata:      metadata,
+		CreatedAt:     env.Created,
 	}, nil
 }
 
@@ -187,13 +188,14 @@ func modelToEnvelope(m GormEventModel) domain.EventEnvelope[any] {
 	}
 
 	return domain.EventEnvelope[any]{
-		ID:          m.ID,
-		AggregateID: m.AggregateID,
-		EventType:   m.EventType,
-		Payload:     payload,
-		Created:     m.CreatedAt,
-		SequenceNo:  m.SequenceNo,
-		Metadata:    metadata,
+		ID:            m.ID,
+		AggregateID:   m.AggregateID,
+		EventType:     m.EventType,
+		Payload:       payload,
+		Created:       m.CreatedAt,
+		SequenceNo:    m.SequenceNo,
+		TransactionID: m.TransactionID,
+		Metadata:      metadata,
 	}
 }
 


### PR DESCRIPTION
Generate a KSUID-based TransactionID in SimpleUnitOfWork.Commit() and
stamp it on all events before persisting, enabling correlation of events
committed together across multiple aggregates.

https://claude.ai/code/session_01FJozJBd7y2obUemDz7kfUw