### PR TITLE
Add GetEventsByTransactionID to EventStore interface

### DIFF
--- a/pkg/eventsourcing/domain/eventstore.go
+++ b/pkg/eventsourcing/domain/eventstore.go
@@ -43,6 +43,12 @@ type EventStore interface {
 	// Returns ErrEventNotFound if the event doesn't exist.
 	GetEventByID(ctx context.Context, eventID string) (EventEnvelope[any], error)
 
+	// GetEventsByTransactionID retrieves all events that share the given transaction ID,
+	// ordered by aggregate ID then sequence number.
+	// transactionID must not be empty; implementations return ErrInvalidEvent if it is.
+	// Returns an empty slice if no events are found.
+	GetEventsByTransactionID(ctx context.Context, transactionID string) ([]EventEnvelope[any], error)
+
 	// GetCurrentVersion returns the current version number for an aggregate.
 	// Returns 0 if the aggregate doesn't exist.
 	GetCurrentVersion(ctx context.Context, aggregateID string) (int, error)

--- a/pkg/eventsourcing/infrastructure/bigquery_store.go
+++ b/pkg/eventsourcing/infrastructure/bigquery_store.go
@@ -243,6 +243,23 @@ func (s *BigQueryEventStore) GetEventByID(ctx context.Context, eventID string) (
 	return bigqueryRowToEnvelope(row)
 }
 
+// GetEventsByTransactionID retrieves all events with the given transaction ID.
+func (s *BigQueryEventStore) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]domain.EventEnvelope[any], error) {
+	if transactionID == "" {
+		return nil, fmt.Errorf("%w: transaction ID must not be empty", domain.ErrInvalidEvent)
+	}
+
+	query := fmt.Sprintf("SELECT id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at FROM %s WHERE transaction_id = @txid ORDER BY aggregate_id ASC, sequence_no ASC",
+		s.fullTableID())
+
+	q := s.client.Query(query)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "txid", Value: transactionID},
+	}
+
+	return s.queryEnvelopes(ctx, q)
+}
+
 // GetCurrentVersion returns the current version for the aggregate.
 // Returns 0 if the aggregate doesn't exist.
 func (s *BigQueryEventStore) GetCurrentVersion(ctx context.Context, aggregateID string) (int, error) {

--- a/pkg/eventsourcing/infrastructure/convert.go
+++ b/pkg/eventsourcing/infrastructure/convert.go
@@ -1,9 +1,21 @@
 package infrastructure
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
+
+// compareEnvelopes orders envelopes by aggregate ID then sequence number.
+// Used to guarantee deterministic ordering from stores that don't natively sort.
+func compareEnvelopes(a, b domain.EventEnvelope[any]) int {
+	if c := cmp.Compare(a.AggregateID, b.AggregateID); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.SequenceNo, b.SequenceNo)
+}
 
 // toAnyMap converts a value to map[string]any using JSON round-trip.
 // Used by multiple EventStore implementations to normalize typed payloads.

--- a/pkg/eventsourcing/infrastructure/dynamo_store.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -244,6 +245,45 @@ func (s *DynamoEventStore) GetEventByID(ctx context.Context, eventID string) (do
 	}
 
 	return dynamoItemToEnvelope(result.Items[0])
+}
+
+// GetEventsByTransactionID retrieves all events with the given transaction ID.
+// This performs a full table scan since transaction_id is not a key attribute.
+func (s *DynamoEventStore) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]domain.EventEnvelope[any], error) {
+	if transactionID == "" {
+		return nil, fmt.Errorf("%w: transaction ID must not be empty", domain.ErrInvalidEvent)
+	}
+
+	var envelopes []domain.EventEnvelope[any]
+
+	input := &dynamodb.ScanInput{
+		TableName:        &s.tableName,
+		FilterExpression: aws.String("transaction_id = :txid"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":txid": &types.AttributeValueMemberS{Value: transactionID},
+		},
+	}
+
+	paginator := dynamodb.NewScanPaginator(s.client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan events by transaction ID %s: %w", transactionID, err)
+		}
+		for _, item := range page.Items {
+			env, err := dynamoItemToEnvelope(item)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert item for transaction %s: %w", transactionID, err)
+			}
+			envelopes = append(envelopes, env)
+		}
+	}
+
+	if envelopes == nil {
+		return []domain.EventEnvelope[any]{}, nil
+	}
+	slices.SortFunc(envelopes, compareEnvelopes)
+	return envelopes, nil
 }
 
 // GetCurrentVersion returns the current version for the aggregate.

--- a/pkg/eventsourcing/infrastructure/dynamo_store_test.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store_test.go
@@ -479,6 +479,59 @@ func TestDynamoStore_Integration(t *testing.T) {
 	})
 }
 
+func TestDynamoStore_GetEventsByTransactionID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transaction ID retrieval", func(t *testing.T) {
+		t.Parallel()
+
+		store := setupDynamoStore(t)
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+
+		// Append events with different transaction IDs
+		if err := store.Append(ctx, "agg-1", -1,
+			createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-100"),
+			createTestEventWithTxID("agg-1", "ev-2", "test.updated", 2, "tx-100"),
+		); err != nil {
+			t.Fatalf("failed to append events: %v", err)
+		}
+		if err := store.Append(ctx, "agg-2", -1,
+			createTestEventWithTxID("agg-2", "ev-3", "test.created", 1, "tx-200"),
+		); err != nil {
+			t.Fatalf("failed to append events: %v", err)
+		}
+
+		// Query by tx-100
+		events, err := store.GetEventsByTransactionID(ctx, "tx-100")
+		if err != nil {
+			t.Fatalf("failed to get events by transaction ID: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events for tx-100, got %d", len(events))
+		}
+
+		// Query by tx-200
+		events, err = store.GetEventsByTransactionID(ctx, "tx-200")
+		if err != nil {
+			t.Fatalf("failed to get events by transaction ID: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event for tx-200, got %d", len(events))
+		}
+
+		// Query non-existent
+		events, err = store.GetEventsByTransactionID(ctx, "tx-nonexistent")
+		if err != nil {
+			t.Fatalf("failed to get events by transaction ID: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected 0 events for nonexistent tx, got %d", len(events))
+		}
+	})
+}
+
 func TestDynamoStore_GetEventsRange(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/eventsourcing/infrastructure/eventstore_test.go
+++ b/pkg/eventsourcing/infrastructure/eventstore_test.go
@@ -793,6 +793,64 @@ func setupMemoryStoreWithCrossAggTxEvents(t *testing.T) domain.EventStore {
 	return store
 }
 
+func setupFileStoreWithCrossAggTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	baseDir := t.TempDir()
+	store, err := infrastructure.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-2", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupGormStoreWithCrossAggTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := setupGormStore(t)
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-2", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupBigQueryStoreWithCrossAggTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := setupBigQueryStore(t)
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-2", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
 func setupBigQueryStoreWithTxEvents(t *testing.T) domain.EventStore {
 	t.Helper()
 	store := setupBigQueryStore(t)
@@ -812,6 +870,11 @@ func setupBigQueryStoreWithTxEvents(t *testing.T) domain.EventStore {
 	return store
 }
 
+type txEventOrder struct {
+	aggregateID string
+	seqNo       int
+}
+
 func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 	t.Parallel()
 
@@ -821,6 +884,7 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 		transactionID string
 		wantCount     int
 		wantErr       bool
+		wantOrder     []txEventOrder
 	}{
 		{
 			name:          "empty transaction ID returns error",
@@ -833,12 +897,14 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 			setupStore:    setupMemoryStoreWithTxEvents,
 			transactionID: "tx-100",
 			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-1", 2}},
 		},
 		{
 			name:          "get events by transaction ID with single match",
 			setupStore:    setupMemoryStoreWithTxEvents,
 			transactionID: "tx-200",
 			wantCount:     1,
+			wantOrder:     []txEventOrder{{"agg-2", 1}},
 		},
 		{
 			name:          "get events by non-existent transaction ID",
@@ -847,22 +913,25 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 			wantCount:     0,
 		},
 		{
-			name:          "cross-aggregate transaction ID returns events from both aggregates",
+			name:          "cross-aggregate transaction ID returns events ordered by aggregate_id then sequence_no",
 			setupStore:    setupMemoryStoreWithCrossAggTxEvents,
 			transactionID: "tx-cross",
 			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-2", 1}},
 		},
 		{
 			name:          "file: get events by transaction ID with multiple matches",
 			setupStore:    setupFileStoreWithTxEvents,
 			transactionID: "tx-100",
 			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-1", 2}},
 		},
 		{
 			name:          "file: get events by transaction ID with single match",
 			setupStore:    setupFileStoreWithTxEvents,
 			transactionID: "tx-200",
 			wantCount:     1,
+			wantOrder:     []txEventOrder{{"agg-2", 1}},
 		},
 		{
 			name:          "file: get events by non-existent transaction ID",
@@ -871,16 +940,25 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 			wantCount:     0,
 		},
 		{
+			name:          "file: cross-aggregate transaction ID returns events ordered by aggregate_id then sequence_no",
+			setupStore:    setupFileStoreWithCrossAggTxEvents,
+			transactionID: "tx-cross",
+			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-2", 1}},
+		},
+		{
 			name:          "gorm: get events by transaction ID with multiple matches",
 			setupStore:    setupGormStoreWithTxEvents,
 			transactionID: "tx-100",
 			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-1", 2}},
 		},
 		{
 			name:          "gorm: get events by transaction ID with single match",
 			setupStore:    setupGormStoreWithTxEvents,
 			transactionID: "tx-200",
 			wantCount:     1,
+			wantOrder:     []txEventOrder{{"agg-2", 1}},
 		},
 		{
 			name:          "gorm: get events by non-existent transaction ID",
@@ -889,22 +967,38 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 			wantCount:     0,
 		},
 		{
+			name:          "gorm: cross-aggregate transaction ID returns events ordered by aggregate_id then sequence_no",
+			setupStore:    setupGormStoreWithCrossAggTxEvents,
+			transactionID: "tx-cross",
+			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-2", 1}},
+		},
+		{
 			name:          "bigquery: get events by transaction ID with multiple matches",
 			setupStore:    setupBigQueryStoreWithTxEvents,
 			transactionID: "tx-100",
 			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-1", 2}},
 		},
 		{
 			name:          "bigquery: get events by transaction ID with single match",
 			setupStore:    setupBigQueryStoreWithTxEvents,
 			transactionID: "tx-200",
 			wantCount:     1,
+			wantOrder:     []txEventOrder{{"agg-2", 1}},
 		},
 		{
 			name:          "bigquery: get events by non-existent transaction ID",
 			setupStore:    setupBigQueryStoreWithTxEvents,
 			transactionID: "tx-nonexistent",
 			wantCount:     0,
+		},
+		{
+			name:          "bigquery: cross-aggregate transaction ID returns events ordered by aggregate_id then sequence_no",
+			setupStore:    setupBigQueryStoreWithCrossAggTxEvents,
+			transactionID: "tx-cross",
+			wantCount:     2,
+			wantOrder:     []txEventOrder{{"agg-1", 1}, {"agg-2", 1}},
 		},
 	}
 
@@ -935,6 +1029,15 @@ func TestEventStore_GetEventsByTransactionID(t *testing.T) {
 			for _, event := range events {
 				if event.TransactionID != tt.transactionID {
 					t.Errorf("expected transaction ID %s, got %s", tt.transactionID, event.TransactionID)
+				}
+			}
+
+			for i, want := range tt.wantOrder {
+				if events[i].AggregateID != want.aggregateID {
+					t.Errorf("event[%d]: expected aggregate_id %q, got %q", i, want.aggregateID, events[i].AggregateID)
+				}
+				if events[i].SequenceNo != want.seqNo {
+					t.Errorf("event[%d]: expected sequence_no %d, got %d", i, want.seqNo, events[i].SequenceNo)
 				}
 			}
 		})

--- a/pkg/eventsourcing/infrastructure/eventstore_test.go
+++ b/pkg/eventsourcing/infrastructure/eventstore_test.go
@@ -701,6 +701,246 @@ func createTestEvent(aggregateID, eventID, eventType string, version int) domain
 	}
 }
 
+func createTestEventWithTxID(aggregateID, eventID, eventType string, version int, txID string) domain.EventEnvelope[any] {
+	return domain.EventEnvelope[any]{
+		ID:            eventID,
+		AggregateID:   aggregateID,
+		EventType:     eventType,
+		Payload:       map[string]interface{}{"test": "data"},
+		Created:       time.Now(),
+		SequenceNo:    version,
+		TransactionID: txID,
+		Metadata:      make(map[string]interface{}),
+	}
+}
+
+func setupMemoryStoreWithTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := infrastructure.NewMemoryStore()
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-100"),
+		createTestEventWithTxID("agg-1", "ev-2", "test.updated", 2, "tx-100"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-3", "test.created", 1, "tx-200"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupGormStoreWithTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := setupGormStore(t)
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-100"),
+		createTestEventWithTxID("agg-1", "ev-2", "test.updated", 2, "tx-100"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-3", "test.created", 1, "tx-200"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupFileStoreWithTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	baseDir := t.TempDir()
+	store, err := infrastructure.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-100"),
+		createTestEventWithTxID("agg-1", "ev-2", "test.updated", 2, "tx-100"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-3", "test.created", 1, "tx-200"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupMemoryStoreWithCrossAggTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := infrastructure.NewMemoryStore()
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-2", "test.created", 1, "tx-cross"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func setupBigQueryStoreWithTxEvents(t *testing.T) domain.EventStore {
+	t.Helper()
+	store := setupBigQueryStore(t)
+	ctx := context.Background()
+
+	if err := store.Append(ctx, "agg-1", -1,
+		createTestEventWithTxID("agg-1", "ev-1", "test.created", 1, "tx-100"),
+		createTestEventWithTxID("agg-1", "ev-2", "test.updated", 2, "tx-100"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	if err := store.Append(ctx, "agg-2", -1,
+		createTestEventWithTxID("agg-2", "ev-3", "test.created", 1, "tx-200"),
+	); err != nil {
+		t.Fatalf("failed to setup store: %v", err)
+	}
+	return store
+}
+
+func TestEventStore_GetEventsByTransactionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setupStore    func(t *testing.T) domain.EventStore
+		transactionID string
+		wantCount     int
+		wantErr       bool
+	}{
+		{
+			name:          "empty transaction ID returns error",
+			setupStore:    setupMemoryStoreWithTxEvents,
+			transactionID: "",
+			wantErr:       true,
+		},
+		{
+			name:          "get events by transaction ID with multiple matches",
+			setupStore:    setupMemoryStoreWithTxEvents,
+			transactionID: "tx-100",
+			wantCount:     2,
+		},
+		{
+			name:          "get events by transaction ID with single match",
+			setupStore:    setupMemoryStoreWithTxEvents,
+			transactionID: "tx-200",
+			wantCount:     1,
+		},
+		{
+			name:          "get events by non-existent transaction ID",
+			setupStore:    setupMemoryStoreWithTxEvents,
+			transactionID: "tx-nonexistent",
+			wantCount:     0,
+		},
+		{
+			name:          "cross-aggregate transaction ID returns events from both aggregates",
+			setupStore:    setupMemoryStoreWithCrossAggTxEvents,
+			transactionID: "tx-cross",
+			wantCount:     2,
+		},
+		{
+			name:          "file: get events by transaction ID with multiple matches",
+			setupStore:    setupFileStoreWithTxEvents,
+			transactionID: "tx-100",
+			wantCount:     2,
+		},
+		{
+			name:          "file: get events by transaction ID with single match",
+			setupStore:    setupFileStoreWithTxEvents,
+			transactionID: "tx-200",
+			wantCount:     1,
+		},
+		{
+			name:          "file: get events by non-existent transaction ID",
+			setupStore:    setupFileStoreWithTxEvents,
+			transactionID: "tx-nonexistent",
+			wantCount:     0,
+		},
+		{
+			name:          "gorm: get events by transaction ID with multiple matches",
+			setupStore:    setupGormStoreWithTxEvents,
+			transactionID: "tx-100",
+			wantCount:     2,
+		},
+		{
+			name:          "gorm: get events by transaction ID with single match",
+			setupStore:    setupGormStoreWithTxEvents,
+			transactionID: "tx-200",
+			wantCount:     1,
+		},
+		{
+			name:          "gorm: get events by non-existent transaction ID",
+			setupStore:    setupGormStoreWithTxEvents,
+			transactionID: "tx-nonexistent",
+			wantCount:     0,
+		},
+		{
+			name:          "bigquery: get events by transaction ID with multiple matches",
+			setupStore:    setupBigQueryStoreWithTxEvents,
+			transactionID: "tx-100",
+			wantCount:     2,
+		},
+		{
+			name:          "bigquery: get events by transaction ID with single match",
+			setupStore:    setupBigQueryStoreWithTxEvents,
+			transactionID: "tx-200",
+			wantCount:     1,
+		},
+		{
+			name:          "bigquery: get events by non-existent transaction ID",
+			setupStore:    setupBigQueryStoreWithTxEvents,
+			transactionID: "tx-nonexistent",
+			wantCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := tt.setupStore(t)
+			defer func() { _ = store.Close() }()
+
+			ctx := context.Background()
+			events, err := store.GetEventsByTransactionID(ctx, tt.transactionID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(events) != tt.wantCount {
+				t.Fatalf("expected %d events, got %d", tt.wantCount, len(events))
+			}
+
+			for _, event := range events {
+				if event.TransactionID != tt.transactionID {
+					t.Errorf("expected transaction ID %s, got %s", tt.transactionID, event.TransactionID)
+				}
+			}
+		})
+	}
+}
+
 func TestToAnyEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/eventsourcing/infrastructure/file_store.go
+++ b/pkg/eventsourcing/infrastructure/file_store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
@@ -305,6 +306,50 @@ func (f *FileStore) GetEventByID(ctx context.Context, eventID string) (domain.Ev
 	}
 
 	return domain.EventEnvelope[any]{}, domain.ErrEventNotFound
+}
+
+// GetEventsByTransactionID retrieves all events with the given transaction ID.
+func (f *FileStore) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]domain.EventEnvelope[any], error) {
+	if transactionID == "" {
+		return nil, fmt.Errorf("%w: transaction ID must not be empty", domain.ErrInvalidEvent)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Ensure aggregates on disk but not yet cached are loaded.
+	entries, err := os.ReadDir(f.baseDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read event directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		aggregateID := entry.Name()[:len(entry.Name())-5]
+		if _, cached := f.cache[aggregateID]; !cached {
+			loaded, loadErr := f.loadFromFile(filepath.Join(f.baseDir, entry.Name()))
+			if loadErr != nil {
+				return nil, fmt.Errorf("failed to load events from %s: %w", entry.Name(), loadErr)
+			}
+			f.cache[aggregateID] = loaded
+		}
+	}
+
+	var result []domain.EventEnvelope[any]
+	for _, events := range f.cache {
+		for _, event := range events {
+			if event.TransactionID == transactionID {
+				result = append(result, event)
+			}
+		}
+	}
+
+	if result == nil {
+		return []domain.EventEnvelope[any]{}, nil
+	}
+	slices.SortFunc(result, compareEnvelopes)
+	return result, nil
 }
 
 // GetCurrentVersion returns the current version for the aggregate.

--- a/pkg/eventsourcing/infrastructure/gorm_repository.go
+++ b/pkg/eventsourcing/infrastructure/gorm_repository.go
@@ -58,6 +58,16 @@ func (r *GormEventRepository) GetEventByID(ctx context.Context, eventID string) 
 	return &event, nil
 }
 
+// GetEventsByTransactionID retrieves all events with a given transaction ID, ordered by aggregate and sequence.
+func (r *GormEventRepository) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]GormEventModel, error) {
+	var events []GormEventModel
+	err := r.db.WithContext(ctx).
+		Where("transaction_id = ?", transactionID).
+		Order("aggregate_id ASC, sequence_no ASC").
+		Find(&events).Error
+	return events, err
+}
+
 // GetCurrentVersion returns the highest sequence number for a given aggregate.
 // Returns 0 if no events exist.
 func (r *GormEventRepository) GetCurrentVersion(ctx context.Context, aggregateID string) (int, error) {

--- a/pkg/eventsourcing/infrastructure/gorm_store.go
+++ b/pkg/eventsourcing/infrastructure/gorm_store.go
@@ -124,6 +124,19 @@ func (s *GormEventStore) GetEventByID(ctx context.Context, eventID string) (doma
 	return modelToEnvelope(*model), nil
 }
 
+// GetEventsByTransactionID retrieves all events with the given transaction ID.
+func (s *GormEventStore) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]domain.EventEnvelope[any], error) {
+	if transactionID == "" {
+		return nil, fmt.Errorf("%w: transaction ID must not be empty", domain.ErrInvalidEvent)
+	}
+
+	models, err := s.repo.GetEventsByTransactionID(ctx, transactionID)
+	if err != nil {
+		return nil, err
+	}
+	return modelsToEnvelopes(models), nil
+}
+
 // GetCurrentVersion returns the current version for the aggregate.
 func (s *GormEventStore) GetCurrentVersion(ctx context.Context, aggregateID string) (int, error) {
 	return s.repo.GetCurrentVersion(ctx, aggregateID)

--- a/pkg/eventsourcing/infrastructure/memory_store.go
+++ b/pkg/eventsourcing/infrastructure/memory_store.go
@@ -3,11 +3,14 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
+
+var _ domain.EventStore = (*MemoryStore)(nil)
 
 // MemoryStore is an in-memory implementation of EventStore.
 // It's useful for testing and development, but not suitable for production
@@ -147,6 +150,31 @@ func (m *MemoryStore) GetEventByID(ctx context.Context, eventID string) (domain.
 
 	// Return a copy to prevent external modification
 	return event, nil
+}
+
+// GetEventsByTransactionID retrieves all events with the given transaction ID.
+func (m *MemoryStore) GetEventsByTransactionID(ctx context.Context, transactionID string) ([]domain.EventEnvelope[any], error) {
+	if transactionID == "" {
+		return nil, fmt.Errorf("%w: transaction ID must not be empty", domain.ErrInvalidEvent)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []domain.EventEnvelope[any]
+	for _, events := range m.events {
+		for _, event := range events {
+			if event.TransactionID == transactionID {
+				result = append(result, event)
+			}
+		}
+	}
+
+	if result == nil {
+		return []domain.EventEnvelope[any]{}, nil
+	}
+	slices.SortFunc(result, compareEnvelopes)
+	return result, nil
 }
 
 // GetCurrentVersion returns the current version for the aggregate.


### PR DESCRIPTION
## Summary
- Adds `GetEventsByTransactionID(ctx, transactionID)` to the `EventStore` interface for retrieving all events sharing a transaction ID
- Implemented across all 5 store backends (Memory, File, GORM, DynamoDB, BigQuery) with consistent `aggregate_id ASC, sequence_no ASC` ordering
- All implementations validate against empty transaction IDs, returning `ErrInvalidEvent`
- Updates CI to Go 1.25 (matching `go.mod`) and golangci-lint-action v7

## Test plan
- [x] Parameterized tests across Memory, File, GORM, BigQuery stores
- [x] Dedicated DynamoDB test with testcontainers
- [x] Cross-aggregate transaction ID retrieval verified
- [x] Empty transaction ID rejection tested
- [x] Non-existent transaction ID returns empty slice
- [x] Full test suite passes (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)