### PR TITLE
feat(auth): add password credential support (closes #12)

### DIFF
--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -38,3 +38,16 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 - Field is `omitempty` in JSON so existing events without a transaction ID remain backward-compatible
 - Added tests: same-commit events share a transaction ID, different commits get different IDs, dispatched events carry the transaction ID
 - **Why:** Enables correlating events across multiple aggregates that were committed together, useful for auditing, debugging, and cross-aggregate consistency tracking
+
+---
+
+### 2026-04-25: Password credential support in pkg/auth
+
+- Added `PasswordCredential` aggregate (`pkg/auth/domain/entities/password_credential.go`) — its own KSUID, linked 1:1 to a `Credential` row of `provider="password"` by `CredentialID`. Bcrypt hash stored only on this row, never on `Credential` and never in any event payload
+- New events `PasswordCredentialCreated` / `PasswordUpdated` carry only metadata (algorithm, timestamps) — no hash, no plaintext
+- Added `PasswordCredentialRepository` (domain interface + GORM impl + table in AutoMigrate)
+- Extended `AuthenticationService` with `RegisterPassword`, `VerifyPassword`, `ImportPasswordCredential`, `UpdatePassword`. Anti-enumeration: `VerifyPassword` returns `ErrInvalidPassword` for both wrong-password and unknown-email, and runs a dummy bcrypt compare to keep timing roughly constant
+- `provider_user_id` for password credentials is the lowercased email; existing OAuth invariant (`provider_user_id = IdP subject`) is untouched
+- Bcrypt via `golang.org/x/crypto/bcrypt`, default cost configurable via `WithBcryptCost`. Algorithm stored on the row to allow future migration (e.g. argon2id)
+- Password support is opt-in via `WithPasswordCredentialRepository`; password methods return `ErrPasswordSupportNotConfigured` until wired
+- **Why:** Apollo and other downstream services need email/password sign-in without bolting their own auth lane on top. OAuth lane untouched; bcrypt blobs from legacy systems can be imported as-is via `ImportPasswordCredential`

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
@@ -16,14 +17,17 @@ import (
 
 // Sentinel errors for the authentication domain.
 var (
-	ErrInvalidProvider    = errors.New("authentication: invalid provider")
-	ErrInvalidState       = errors.New("authentication: invalid state parameter")
-	ErrCodeExchangeFailed = errors.New("authentication: code exchange failed")
-	ErrSessionNotFound    = errors.New("authentication: session not found")
-	ErrSessionExpired     = errors.New("authentication: session expired")
-	ErrSessionRevoked     = errors.New("authentication: session revoked")
-	ErrTokenRefreshFailed = errors.New("authentication: token refresh failed")
-	ErrCredentialNotFound = errors.New("authentication: credential not found")
+	ErrInvalidProvider               = errors.New("authentication: invalid provider")
+	ErrInvalidState                  = errors.New("authentication: invalid state parameter")
+	ErrCodeExchangeFailed            = errors.New("authentication: code exchange failed")
+	ErrSessionNotFound               = errors.New("authentication: session not found")
+	ErrSessionExpired                = errors.New("authentication: session expired")
+	ErrSessionRevoked                = errors.New("authentication: session revoked")
+	ErrTokenRefreshFailed            = errors.New("authentication: token refresh failed")
+	ErrCredentialNotFound            = errors.New("authentication: credential not found")
+	ErrEmailAlreadyTaken             = errors.New("authentication: email already registered with a password")
+	ErrPasswordSupportNotConfigured  = errors.New("authentication: password support not configured")
+	ErrPasswordCredentialMissing     = errors.New("authentication: password credential not found for agent")
 )
 
 // AuthRequest represents the result of initiating an OAuth authorization flow.
@@ -114,6 +118,27 @@ type AuthenticationService interface {
 	// For new users, a personal Account is also created with the agent as owner.
 	FindOrCreateAgent(ctx context.Context, userInfo UserInfo) (*entities.Agent, *entities.Credential, *entities.Account, error)
 
+	// RegisterPassword creates a new Agent + personal Account + Credential
+	// (provider="password") + PasswordCredential. Returns ErrEmailAlreadyTaken
+	// when a password credential for the email already exists.
+	RegisterPassword(ctx context.Context, email, displayName, plaintext string) (*entities.Agent, *entities.Credential, *entities.Account, error)
+
+	// VerifyPassword authenticates an email + plaintext pair against a stored
+	// PasswordCredential and returns the associated Agent, Credential and
+	// (optional) personal Account on success. To prevent account enumeration,
+	// both wrong-password and unknown-email cases return ErrInvalidPassword.
+	VerifyPassword(ctx context.Context, email, plaintext string) (*entities.Agent, *entities.Credential, *entities.Account, error)
+
+	// ImportPasswordCredential imports an already-hashed legacy bcrypt blob
+	// against a caller-supplied agentID/accountID. Idempotent on
+	// (provider="password", lower(email)). Used for bulk migration where
+	// existing foreign keys must remain valid.
+	ImportPasswordCredential(ctx context.Context, email, displayName, bcryptHash, agentID, accountID string) error
+
+	// UpdatePassword rotates the stored password for the given agent.
+	// Verifies oldPlaintext before applying the change.
+	UpdatePassword(ctx context.Context, agentID, oldPlaintext, newPlaintext string) error
+
 	// IssueIdentityToken issues a signed JWT for the given agent.
 	// Returns ("", nil) if no JWTService is configured.
 	IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error)
@@ -140,16 +165,18 @@ type OAuthProviderRegistry map[string]OAuthProvider
 // DefaultAuthenticationService implements AuthenticationService using OAuth providers
 // and domain aggregates.
 type DefaultAuthenticationService struct {
-	providers     OAuthProviderRegistry
-	agents        repositories.AgentRepository
-	credentials   repositories.CredentialRepository
-	sessions      repositories.AuthSessionRepository
-	accounts      repositories.AccountRepository
-	eventStore    esDomain.EventStore
-	tokens        TokenStore
-	authorization AuthorizationChecker
-	logger        Logger
-	jwtService    JWTService
+	providers           OAuthProviderRegistry
+	agents              repositories.AgentRepository
+	credentials         repositories.CredentialRepository
+	sessions            repositories.AuthSessionRepository
+	accounts            repositories.AccountRepository
+	passwordCredentials repositories.PasswordCredentialRepository
+	eventStore          esDomain.EventStore
+	tokens              TokenStore
+	authorization       AuthorizationChecker
+	logger              Logger
+	jwtService          JWTService
+	bcryptCost          int
 }
 
 // NewDefaultAuthenticationService creates a new DefaultAuthenticationService.
@@ -488,3 +515,307 @@ func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, a
 	}
 	return s.jwtService.IssueToken(ctx, agent, accounts, activeAccountID)
 }
+
+// normalizeEmail returns the canonical form of an email used as the
+// password credential's provider_user_id.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// RegisterPassword creates a new Agent + personal Account + Credential
+// (provider="password") + PasswordCredential.
+func (s *DefaultAuthenticationService) RegisterPassword(ctx context.Context, email, displayName, plaintext string) (*entities.Agent, *entities.Credential, *entities.Account, error) {
+	if s.passwordCredentials == nil {
+		return nil, nil, nil, ErrPasswordSupportNotConfigured
+	}
+	normalizedEmail := normalizeEmail(email)
+	if normalizedEmail == "" {
+		return nil, nil, nil, fmt.Errorf("authentication: email must not be empty")
+	}
+	if plaintext == "" {
+		return nil, nil, nil, fmt.Errorf("authentication: password must not be empty")
+	}
+
+	existing, err := s.credentials.FindByProvider(ctx, entities.ProviderPassword, normalizedEmail)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: lookup existing credential: %w", err)
+	}
+	if existing != nil {
+		return nil, nil, nil, ErrEmailAlreadyTaken
+	}
+
+	algorithm, hash, err := hashPassword(plaintext, s.bcryptCost)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: hash password: %w", err)
+	}
+
+	agentID := ksuid.New().String()
+	agent, err := new(entities.Agent).With(agentID, displayName, entities.AgentTypePerson)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: create agent: %w", err)
+	}
+
+	accountID := ksuid.New().String()
+	account, err := new(entities.Account).With(accountID, displayName+"'s Account", entities.AccountTypePersonal)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: create account: %w", err)
+	}
+	if err := account.AddMember(agentID, entities.RoleOwner); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: add account member: %w", err)
+	}
+
+	credentialID := ksuid.New().String()
+	credential, err := new(entities.Credential).With(credentialID, agentID, entities.ProviderPassword, normalizedEmail, normalizedEmail, displayName)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: create credential: %w", err)
+	}
+
+	passwordCredentialID := ksuid.New().String()
+	passwordCredential, err := new(entities.PasswordCredential).With(passwordCredentialID, credentialID, algorithm, hash)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: create password credential: %w", err)
+	}
+
+	if s.eventStore != nil {
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		if err := uow.Track(agent, account, credential, passwordCredential); err != nil {
+			return nil, nil, nil, fmt.Errorf("authentication: track entities: %w", err)
+		}
+		if err := uow.Commit(ctx); err != nil {
+			return nil, nil, nil, fmt.Errorf("authentication: commit unit of work: %w", err)
+		}
+	}
+
+	if err := s.agents.Save(ctx, agent); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: save agent: %w", err)
+	}
+	if s.accounts != nil {
+		if err := s.accounts.Save(ctx, account); err != nil {
+			return nil, nil, nil, fmt.Errorf("authentication: save account: %w", err)
+		}
+		if err := s.accounts.SaveMember(ctx, accountID, agentID, entities.RoleOwner); err != nil {
+			return nil, nil, nil, fmt.Errorf("authentication: save account member: %w", err)
+		}
+	}
+	if err := s.credentials.Save(ctx, credential); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: save credential: %w", err)
+	}
+	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: save password credential: %w", err)
+	}
+
+	return agent, credential, account, nil
+}
+
+// VerifyPassword authenticates an email + plaintext pair. Returns
+// ErrInvalidPassword for both wrong-password and unknown-email so callers
+// cannot enumerate registered emails.
+func (s *DefaultAuthenticationService) VerifyPassword(ctx context.Context, email, plaintext string) (*entities.Agent, *entities.Credential, *entities.Account, error) {
+	if s.passwordCredentials == nil {
+		return nil, nil, nil, ErrPasswordSupportNotConfigured
+	}
+	normalizedEmail := normalizeEmail(email)
+
+	credential, err := s.credentials.FindByProvider(ctx, entities.ProviderPassword, normalizedEmail)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: lookup credential: %w", err)
+	}
+	if credential == nil || !credential.Active() {
+		// Constant-time-ish: still hash the plaintext against a junk hash so
+		// failed lookups don't return measurably faster than failed compares.
+		// Errors from the dummy compare are discarded.
+		_ = verifyPassword(entities.PasswordAlgorithmBcrypt, dummyBcryptHash, plaintext)
+		s.logger.Info(ctx, "password verify: no active credential", "email", normalizedEmail)
+		return nil, nil, nil, ErrInvalidPassword
+	}
+
+	passwordCredential, err := s.passwordCredentials.FindByCredentialID(ctx, credential.GetID())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: lookup password credential: %w", err)
+	}
+	if passwordCredential == nil {
+		_ = verifyPassword(entities.PasswordAlgorithmBcrypt, dummyBcryptHash, plaintext)
+		s.logger.Info(ctx, "password verify: missing password row", "credential_id", credential.GetID())
+		return nil, nil, nil, ErrInvalidPassword
+	}
+
+	if err := verifyPassword(passwordCredential.Algorithm(), passwordCredential.Hash(), plaintext); err != nil {
+		if errors.Is(err, ErrInvalidPassword) {
+			return nil, nil, nil, ErrInvalidPassword
+		}
+		return nil, nil, nil, fmt.Errorf("authentication: verify password: %w", err)
+	}
+
+	agent, err := s.agents.FindByID(ctx, credential.AgentID())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: load agent: %w", err)
+	}
+	if agent == nil {
+		return nil, nil, nil, fmt.Errorf("authentication: agent %s not found", credential.AgentID())
+	}
+
+	var account *entities.Account
+	if s.accounts != nil {
+		account, err = s.accounts.FindPersonalByMember(ctx, agent.GetID())
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("authentication: load personal account: %w", err)
+		}
+	}
+
+	if err := credential.MarkUsed(); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: mark credential used: %w", err)
+	}
+	if err := s.credentials.Save(ctx, credential); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: save credential: %w", err)
+	}
+	passwordCredential.MarkVerified()
+	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {
+		return nil, nil, nil, fmt.Errorf("authentication: save password credential: %w", err)
+	}
+
+	return agent, credential, account, nil
+}
+
+// ImportPasswordCredential imports a pre-hashed bcrypt blob against existing
+// agent/account IDs. Idempotent on (provider="password", lower(email)).
+func (s *DefaultAuthenticationService) ImportPasswordCredential(ctx context.Context, email, displayName, bcryptHash, agentID, accountID string) error {
+	if s.passwordCredentials == nil {
+		return ErrPasswordSupportNotConfigured
+	}
+	normalizedEmail := normalizeEmail(email)
+	if normalizedEmail == "" {
+		return fmt.Errorf("authentication: email must not be empty")
+	}
+	if bcryptHash == "" {
+		return fmt.Errorf("authentication: bcrypt hash must not be empty")
+	}
+	if agentID == "" {
+		return fmt.Errorf("authentication: agent ID must not be empty")
+	}
+
+	existing, err := s.credentials.FindByProvider(ctx, entities.ProviderPassword, normalizedEmail)
+	if err != nil {
+		return fmt.Errorf("authentication: lookup credential: %w", err)
+	}
+	if existing != nil {
+		return nil
+	}
+
+	agent, err := s.agents.FindByID(ctx, agentID)
+	if err != nil {
+		return fmt.Errorf("authentication: load agent: %w", err)
+	}
+	if agent == nil {
+		return fmt.Errorf("authentication: agent %s not found", agentID)
+	}
+	if accountID != "" && s.accounts != nil {
+		account, err := s.accounts.FindByID(ctx, accountID)
+		if err != nil {
+			return fmt.Errorf("authentication: load account: %w", err)
+		}
+		if account == nil {
+			return fmt.Errorf("authentication: account %s not found", accountID)
+		}
+	}
+
+	credentialID := ksuid.New().String()
+	credential, err := new(entities.Credential).With(credentialID, agentID, entities.ProviderPassword, normalizedEmail, normalizedEmail, displayName)
+	if err != nil {
+		return fmt.Errorf("authentication: create credential: %w", err)
+	}
+
+	passwordCredentialID := ksuid.New().String()
+	passwordCredential, err := new(entities.PasswordCredential).With(passwordCredentialID, credentialID, entities.PasswordAlgorithmBcrypt, bcryptHash)
+	if err != nil {
+		return fmt.Errorf("authentication: create password credential: %w", err)
+	}
+
+	if s.eventStore != nil {
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		if err := uow.Track(credential, passwordCredential); err != nil {
+			return fmt.Errorf("authentication: track entities: %w", err)
+		}
+		if err := uow.Commit(ctx); err != nil {
+			return fmt.Errorf("authentication: commit unit of work: %w", err)
+		}
+	}
+
+	if err := s.credentials.Save(ctx, credential); err != nil {
+		return fmt.Errorf("authentication: save credential: %w", err)
+	}
+	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {
+		return fmt.Errorf("authentication: save password credential: %w", err)
+	}
+	return nil
+}
+
+// UpdatePassword rotates the stored password for the given agent.
+func (s *DefaultAuthenticationService) UpdatePassword(ctx context.Context, agentID, oldPlaintext, newPlaintext string) error {
+	if s.passwordCredentials == nil {
+		return ErrPasswordSupportNotConfigured
+	}
+	if agentID == "" {
+		return fmt.Errorf("authentication: agent ID must not be empty")
+	}
+	if newPlaintext == "" {
+		return fmt.Errorf("authentication: new password must not be empty")
+	}
+
+	creds, err := s.credentials.FindByAgent(ctx, agentID)
+	if err != nil {
+		return fmt.Errorf("authentication: lookup credentials: %w", err)
+	}
+	var passwordCredentialEntity *entities.Credential
+	for _, c := range creds {
+		if c.Provider() == entities.ProviderPassword && c.Active() {
+			passwordCredentialEntity = c
+			break
+		}
+	}
+	if passwordCredentialEntity == nil {
+		return ErrPasswordCredentialMissing
+	}
+
+	pc, err := s.passwordCredentials.FindByCredentialID(ctx, passwordCredentialEntity.GetID())
+	if err != nil {
+		return fmt.Errorf("authentication: lookup password credential: %w", err)
+	}
+	if pc == nil {
+		return ErrPasswordCredentialMissing
+	}
+
+	if err := verifyPassword(pc.Algorithm(), pc.Hash(), oldPlaintext); err != nil {
+		if errors.Is(err, ErrInvalidPassword) {
+			return ErrInvalidPassword
+		}
+		return fmt.Errorf("authentication: verify old password: %w", err)
+	}
+
+	algorithm, hash, err := hashPassword(newPlaintext, s.bcryptCost)
+	if err != nil {
+		return fmt.Errorf("authentication: hash new password: %w", err)
+	}
+	if err := pc.Update(algorithm, hash); err != nil {
+		return fmt.Errorf("authentication: update password credential: %w", err)
+	}
+
+	// Note: we deliberately do not commit a UnitOfWork here. The aggregate
+	// was rehydrated from the read-model via Restore(), which sets
+	// sequenceNo=0; appending to the event store with expectedVersion=0
+	// would conflict with the live history. This matches the existing
+	// pattern in FindOrCreateAgent's MarkUsed path (read-model-only
+	// mutations on rehydrated aggregates skip the event store).
+	if err := s.passwordCredentials.Save(ctx, pc); err != nil {
+		return fmt.Errorf("authentication: save password credential: %w", err)
+	}
+	return nil
+}
+
+// dummyBcryptHash is a real bcrypt(DefaultCost) hash used to keep
+// VerifyPassword's timing roughly constant when no credential row exists
+// for the given email. Generated once via bcrypt.GenerateFromPassword over
+// an unguessable plaintext so it parses correctly and forces a real
+// CompareHashAndPassword cycle. A unit test asserts that comparing it
+// returns ErrMismatchedHashAndPassword (not a parse error) so the timing
+// shield does not regress to a no-op.
+const dummyBcryptHash = "$2a$10$EEI56WhQ.0l6UnEoiuE3bOZM7ADLEEdvDaI6KNGpodfiLnQnL7kbO"

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -603,6 +603,17 @@ func (s *DefaultAuthenticationService) RegisterPassword(ctx context.Context, ema
 		}
 	}
 	if err := s.credentials.Save(ctx, credential); err != nil {
+		// Race against a concurrent register: another caller wrote a
+		// credential row for the same (provider, lower(email)) between
+		// our pre-check and this Save. Translate to the same sentinel
+		// the pre-check would have returned. Note: the agent + account
+		// rows we wrote above are now orphaned; cleaning them up
+		// requires wrapping projection writes in a DB transaction,
+		// which is tracked as a follow-up (the same race exists in
+		// FindOrCreateAgent for OAuth flows today).
+		if errors.Is(err, repositories.ErrDuplicateCredential) {
+			return nil, nil, nil, ErrEmailAlreadyTaken
+		}
 		return nil, nil, nil, fmt.Errorf("authentication: save credential: %w", err)
 	}
 	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {
@@ -768,6 +779,17 @@ func (s *DefaultAuthenticationService) ImportPasswordCredential(ctx context.Cont
 	}
 
 	if err := s.credentials.Save(ctx, credential); err != nil {
+		// Race-induced dup-key after an idempotent pre-check returned
+		// nil: another caller landed the same (provider, lower(email))
+		// in the meantime. Treat the import as a no-op to preserve
+		// idempotent semantics. The CredentialCreated and
+		// PasswordCredentialCreated events we already committed to the
+		// event store describe an aggregate without a projection row;
+		// this is the same divergence the broader transaction
+		// follow-up will close.
+		if errors.Is(err, repositories.ErrDuplicateCredential) {
+			return nil
+		}
 		return fmt.Errorf("authentication: save credential: %w", err)
 	}
 	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
@@ -13,6 +14,7 @@ import (
 	esApplication "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	esDomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"github.com/segmentio/ksuid"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Sentinel errors for the authentication domain.
@@ -177,6 +179,8 @@ type DefaultAuthenticationService struct {
 	logger              Logger
 	jwtService          JWTService
 	bcryptCost          int
+	dummyHashOnce       sync.Once
+	dummyHashValue      string
 }
 
 // NewDefaultAuthenticationService creates a new DefaultAuthenticationService.
@@ -621,11 +625,8 @@ func (s *DefaultAuthenticationService) VerifyPassword(ctx context.Context, email
 		return nil, nil, nil, fmt.Errorf("authentication: lookup credential: %w", err)
 	}
 	if credential == nil || !credential.Active() {
-		// Constant-time-ish: still hash the plaintext against a junk hash so
-		// failed lookups don't return measurably faster than failed compares.
-		// Errors from the dummy compare are discarded.
-		_ = verifyPassword(entities.PasswordAlgorithmBcrypt, dummyBcryptHash, plaintext)
-		s.logger.Info(ctx, "password verify: no active credential", "email", normalizedEmail)
+		s.runTimingShield(ctx, plaintext)
+		s.logger.Warn(ctx, "auth: password verify failed (no active credential)", "email", normalizedEmail)
 		return nil, nil, nil, ErrInvalidPassword
 	}
 
@@ -634,16 +635,21 @@ func (s *DefaultAuthenticationService) VerifyPassword(ctx context.Context, email
 		return nil, nil, nil, fmt.Errorf("authentication: lookup password credential: %w", err)
 	}
 	if passwordCredential == nil {
-		_ = verifyPassword(entities.PasswordAlgorithmBcrypt, dummyBcryptHash, plaintext)
-		s.logger.Info(ctx, "password verify: missing password row", "credential_id", credential.GetID())
+		s.runTimingShield(ctx, plaintext)
+		s.logger.Warn(ctx, "auth: password verify failed (missing password row)", "credential_id", credential.GetID())
 		return nil, nil, nil, ErrInvalidPassword
 	}
 
 	if err := verifyPassword(passwordCredential.Algorithm(), passwordCredential.Hash(), plaintext); err != nil {
-		if errors.Is(err, ErrInvalidPassword) {
-			return nil, nil, nil, ErrInvalidPassword
+		// Map any verify failure (mismatch OR corrupt hash / unsupported
+		// algorithm) to ErrInvalidPassword so timing and error-type do not
+		// distinguish the two cases. The internal log retains detail.
+		if !errors.Is(err, ErrInvalidPassword) {
+			s.logger.Error(ctx, "auth: password compare failed (non-mismatch error)", "credential_id", credential.GetID(), "error", err)
+		} else {
+			s.logger.Warn(ctx, "auth: password verify failed (mismatch)", "credential_id", credential.GetID())
 		}
-		return nil, nil, nil, fmt.Errorf("authentication: verify password: %w", err)
+		return nil, nil, nil, ErrInvalidPassword
 	}
 
 	agent, err := s.agents.FindByID(ctx, credential.AgentID())
@@ -662,18 +668,32 @@ func (s *DefaultAuthenticationService) VerifyPassword(ctx context.Context, email
 		}
 	}
 
+	// Housekeeping writes (last-used / last-verified) are best-effort: the
+	// password was correct, so denying login because a metadata projection
+	// failed to update would be a worse UX than a stale timestamp.
 	if err := credential.MarkUsed(); err != nil {
-		return nil, nil, nil, fmt.Errorf("authentication: mark credential used: %w", err)
-	}
-	if err := s.credentials.Save(ctx, credential); err != nil {
-		return nil, nil, nil, fmt.Errorf("authentication: save credential: %w", err)
+		s.logger.Warn(ctx, "auth: mark credential used failed", "credential_id", credential.GetID(), "error", err)
+	} else if err := s.credentials.Save(ctx, credential); err != nil {
+		s.logger.Warn(ctx, "auth: save credential after verify failed", "credential_id", credential.GetID(), "error", err)
 	}
 	passwordCredential.MarkVerified()
 	if err := s.passwordCredentials.Save(ctx, passwordCredential); err != nil {
-		return nil, nil, nil, fmt.Errorf("authentication: save password credential: %w", err)
+		s.logger.Warn(ctx, "auth: save password credential after verify failed", "password_credential_id", passwordCredential.GetID(), "error", err)
 	}
 
 	return agent, credential, account, nil
+}
+
+// runTimingShield runs a real bcrypt compare against a parseable dummy
+// hash so the unknown-email / orphan-row branches of VerifyPassword do
+// not return measurably faster than a real failed login. The dummy hash
+// matches the service's configured cost. A non-mismatch error from the
+// compare means the shield is degraded; we log at Error level so it
+// surfaces in operational telemetry instead of being silent.
+func (s *DefaultAuthenticationService) runTimingShield(ctx context.Context, plaintext string) {
+	if err := verifyPassword(entities.PasswordAlgorithmBcrypt, s.dummyBcryptHash(ctx), plaintext); err != nil && !errors.Is(err, ErrInvalidPassword) {
+		s.logger.Error(ctx, "auth: timing-shield bcrypt compare failed (shield degraded)", "error", err)
+	}
 }
 
 // ImportPasswordCredential imports a pre-hashed bcrypt blob against existing
@@ -799,23 +819,45 @@ func (s *DefaultAuthenticationService) UpdatePassword(ctx context.Context, agent
 		return fmt.Errorf("authentication: update password credential: %w", err)
 	}
 
-	// Note: we deliberately do not commit a UnitOfWork here. The aggregate
-	// was rehydrated from the read-model via Restore(), which sets
-	// sequenceNo=0; appending to the event store with expectedVersion=0
-	// would conflict with the live history. This matches the existing
-	// pattern in FindOrCreateAgent's MarkUsed path (read-model-only
-	// mutations on rehydrated aggregates skip the event store).
+	// The aggregate was rehydrated via Restore(), which resets sequenceNo
+	// to 0; committing a UnitOfWork now would call EventStore.Append with
+	// expectedVersion=0 and conflict with the existing event stream. As a
+	// stop-gap we drop the PasswordUpdated event recorded by pc.Update by
+	// clearing the uncommitted slice — this keeps the projection update
+	// safe but means password rotations are NOT in the audit log. A
+	// follow-up should rebuild the aggregate from the event store before
+	// updating so the event lands durably.
+	pc.ClearUncommittedEvents()
 	if err := s.passwordCredentials.Save(ctx, pc); err != nil {
 		return fmt.Errorf("authentication: save password credential: %w", err)
 	}
 	return nil
 }
 
-// dummyBcryptHash is a real bcrypt(DefaultCost) hash used to keep
-// VerifyPassword's timing roughly constant when no credential row exists
-// for the given email. Generated once via bcrypt.GenerateFromPassword over
-// an unguessable plaintext so it parses correctly and forces a real
-// CompareHashAndPassword cycle. A unit test asserts that comparing it
-// returns ErrMismatchedHashAndPassword (not a parse error) so the timing
-// shield does not regress to a no-op.
-const dummyBcryptHash = "$2a$10$EEI56WhQ.0l6UnEoiuE3bOZM7ADLEEdvDaI6KNGpodfiLnQnL7kbO"
+// fallbackDummyBcryptHash is a real bcrypt(DefaultCost) hash used as a
+// last-resort timing-shield target if dummy-hash generation ever fails at
+// runtime. The corresponding plaintext is intentionally unguessable.
+const fallbackDummyBcryptHash = "$2a$10$EEI56WhQ.0l6UnEoiuE3bOZM7ADLEEdvDaI6KNGpodfiLnQnL7kbO"
+
+// dummyBcryptHash returns a parseable bcrypt hash whose cost matches the
+// service's configured bcryptCost, generated once per service instance.
+// VerifyPassword uses it as a timing-equalization target on the
+// unknown-email branch. Matching the live cost keeps the unknown-email
+// path indistinguishable from a real failed login by elapsed time, even
+// when WithBcryptCost configures a non-default cost.
+func (s *DefaultAuthenticationService) dummyBcryptHash(ctx context.Context) string {
+	s.dummyHashOnce.Do(func() {
+		cost := s.bcryptCost
+		if cost <= 0 {
+			cost = bcrypt.DefaultCost
+		}
+		out, err := bcrypt.GenerateFromPassword([]byte("__pericarp_dummy_unguessable_plaintext__"), cost)
+		if err != nil {
+			s.logger.Error(ctx, "auth: dummy hash generation failed; timing shield degraded to fallback cost", "error", err, "configured_cost", cost)
+			s.dummyHashValue = fallbackDummyBcryptHash
+			return
+		}
+		s.dummyHashValue = string(out)
+	})
+	return s.dummyHashValue
+}

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	"github.com/akeemphilbert/pericarp/pkg/ddd"
 	esApplication "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	esDomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"github.com/segmentio/ksuid"
@@ -709,6 +710,12 @@ func (s *DefaultAuthenticationService) ImportPasswordCredential(ctx context.Cont
 	if bcryptHash == "" {
 		return fmt.Errorf("authentication: bcrypt hash must not be empty")
 	}
+	// Reject malformed hashes upfront so a corrupt migration row fails at
+	// import time rather than silently turning into ErrInvalidPassword on
+	// every future login attempt for that account.
+	if _, costErr := bcrypt.Cost([]byte(bcryptHash)); costErr != nil {
+		return fmt.Errorf("authentication: invalid bcrypt hash: %w", costErr)
+	}
 	if agentID == "" {
 		return fmt.Errorf("authentication: agent ID must not be empty")
 	}
@@ -815,19 +822,41 @@ func (s *DefaultAuthenticationService) UpdatePassword(ctx context.Context, agent
 	if err != nil {
 		return fmt.Errorf("authentication: hash new password: %w", err)
 	}
+
+	// The aggregate was rehydrated from the projection via Restore(), which
+	// resets sequenceNo to 0. If an EventStore is configured we must reseat
+	// the BaseEntity to the stream's true current version before recording
+	// a new event, otherwise UnitOfWork.Commit would call Append with
+	// expectedVersion=0 and conflict with the existing stream — and skipping
+	// the commit would silently drop the PasswordUpdated event, breaking
+	// the audit trail.
+	if s.eventStore != nil {
+		currentVersion, verErr := s.eventStore.GetCurrentVersion(ctx, pc.GetID())
+		if verErr != nil {
+			return fmt.Errorf("authentication: load password credential version: %w", verErr)
+		}
+		pc.BaseEntity = ddd.RestoreBaseEntity(pc.GetID(), currentVersion)
+	}
+
 	if err := pc.Update(algorithm, hash); err != nil {
 		return fmt.Errorf("authentication: update password credential: %w", err)
 	}
 
-	// The aggregate was rehydrated via Restore(), which resets sequenceNo
-	// to 0; committing a UnitOfWork now would call EventStore.Append with
-	// expectedVersion=0 and conflict with the existing event stream. As a
-	// stop-gap we drop the PasswordUpdated event recorded by pc.Update by
-	// clearing the uncommitted slice — this keeps the projection update
-	// safe but means password rotations are NOT in the audit log. A
-	// follow-up should rebuild the aggregate from the event store before
-	// updating so the event lands durably.
-	pc.ClearUncommittedEvents()
+	if s.eventStore != nil {
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		if err := uow.Track(pc); err != nil {
+			return fmt.Errorf("authentication: track password credential: %w", err)
+		}
+		if err := uow.Commit(ctx); err != nil {
+			return fmt.Errorf("authentication: commit password update: %w", err)
+		}
+	} else {
+		// No event store wired: the recorded event has nowhere durable to
+		// land, so drop it from the aggregate before saving the projection
+		// to keep state consistent on subsequent operations.
+		pc.ClearUncommittedEvents()
+	}
+
 	if err := s.passwordCredentials.Save(ctx, pc); err != nil {
 		return fmt.Errorf("authentication: save password credential: %w", err)
 	}

--- a/pkg/auth/application/options.go
+++ b/pkg/auth/application/options.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	esDomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
 
@@ -53,5 +54,26 @@ func WithJWTService(js JWTService) AuthServiceOption {
 		if js != nil {
 			s.jwtService = js
 		}
+	}
+}
+
+// WithPasswordCredentialRepository wires a PasswordCredentialRepository for
+// password authentication support. The password methods on
+// AuthenticationService return ErrPasswordSupportNotConfigured until this
+// is set.
+func WithPasswordCredentialRepository(repo repositories.PasswordCredentialRepository) AuthServiceOption {
+	return func(s *DefaultAuthenticationService) {
+		if repo != nil {
+			s.passwordCredentials = repo
+		}
+	}
+}
+
+// WithBcryptCost overrides the bcrypt cost used when hashing newly
+// registered or updated passwords. A non-positive value falls back to
+// bcrypt.DefaultCost.
+func WithBcryptCost(cost int) AuthServiceOption {
+	return func(s *DefaultAuthenticationService) {
+		s.bcryptCost = cost
 	}
 }

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -1,9 +1,11 @@
 package application_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -369,6 +371,207 @@ func TestDummyBcryptHash_IsValid(t *testing.T) {
 	// error: it must be ErrInvalidPassword (not wrapped/unrelated).
 	if _, _, _, err := svc.VerifyPassword(ctx, "ghost@example.com", "any"); !errors.Is(err, application.ErrInvalidPassword) {
 		t.Errorf("error = %v, want ErrInvalidPassword (dummy hash may be malformed)", err)
+	}
+}
+
+// newSQLiteDeps returns the SQLite-backed service plus the underlying
+// repos so a test can poke at projections directly.
+func newSQLiteDeps(t *testing.T) (*application.DefaultAuthenticationService, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+	return svc, db
+}
+
+func TestImportPasswordCredential_DoesNotOverwriteOnReimport(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, db := newSQLiteDeps(t)
+	pcRepo := gorminfra.NewPasswordCredentialRepository(db)
+
+	owner, _, ownerAccount, err := svc.RegisterPassword(ctx, "owner@example.com", "Owner", "ownerpass")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	firstHash, _ := bcrypt.GenerateFromPassword([]byte("legacy-pass"), bcrypt.MinCost)
+	if err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(firstHash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	credRepo := gorminfra.NewCredentialRepository(db)
+	cred, err := credRepo.FindByProvider(ctx, entities.ProviderPassword, "legacy@example.com")
+	if err != nil || cred == nil {
+		t.Fatalf("locate credential: %v %+v", err, cred)
+	}
+	pcBefore, err := pcRepo.FindByCredentialID(ctx, cred.GetID())
+	if err != nil || pcBefore == nil {
+		t.Fatalf("locate password credential: %v %+v", err, pcBefore)
+	}
+
+	// Re-import with a DIFFERENT hash. Idempotency means the second call
+	// is a no-op — the stored hash must not change.
+	secondHash, _ := bcrypt.GenerateFromPassword([]byte("different-pass"), bcrypt.MinCost)
+	if err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(secondHash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	pcAfter, err := pcRepo.FindByCredentialID(ctx, cred.GetID())
+	if err != nil || pcAfter == nil {
+		t.Fatalf("locate password credential after: %v %+v", err, pcAfter)
+	}
+	if pcAfter.GetID() != pcBefore.GetID() {
+		t.Errorf("password credential ID changed: %q -> %q", pcBefore.GetID(), pcAfter.GetID())
+	}
+	if pcAfter.Hash() != pcBefore.Hash() {
+		t.Errorf("hash was overwritten on re-import; want unchanged")
+	}
+
+	// The original password must still verify; the second hash must not.
+	if _, _, _, err := svc.VerifyPassword(ctx, "legacy@example.com", "legacy-pass"); err != nil {
+		t.Errorf("original password no longer verifies: %v", err)
+	}
+	if _, _, _, err := svc.VerifyPassword(ctx, "legacy@example.com", "different-pass"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("second-import password should not have taken effect, got %v", err)
+	}
+}
+
+func TestImportPasswordCredential_NormalizesEmail(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, db := newSQLiteDeps(t)
+
+	owner, _, ownerAccount, err := svc.RegisterPassword(ctx, "owner@example.com", "Owner", "ownerpass")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	hash, _ := bcrypt.GenerateFromPassword([]byte("legacy-pass"), bcrypt.MinCost)
+
+	if err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(hash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	// Mixed-case + whitespace must hit the existing row, not create a new
+	// one. The total row count for provider=password is the seed (1) +
+	// legacy (1) = 2.
+	if err := svc.ImportPasswordCredential(ctx, "  LEGACY@Example.COM  ", "Legacy", string(hash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("normalized re-import: %v", err)
+	}
+	credRepo := gorminfra.NewCredentialRepository(db)
+	creds, err := credRepo.FindByEmail(ctx, "legacy@example.com")
+	if err != nil {
+		t.Fatalf("FindByEmail: %v", err)
+	}
+	if len(creds) != 1 {
+		t.Errorf("expected exactly 1 credential for legacy@example.com, got %d", len(creds))
+	}
+}
+
+func TestVerifyPassword_OrphanCredentialRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, db := newSQLiteDeps(t)
+	credRepo := gorminfra.NewCredentialRepository(db)
+	pcRepo := gorminfra.NewPasswordCredentialRepository(db)
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+	cred, err := credRepo.FindByProvider(ctx, entities.ProviderPassword, "alice@example.com")
+	if err != nil || cred == nil {
+		t.Fatalf("locate credential: %v %+v", err, cred)
+	}
+	// Drop the password row but leave the parent credential — simulating
+	// data drift between the two tables. VerifyPassword must still return
+	// ErrInvalidPassword and exercise the timing shield.
+	if err := pcRepo.Delete(ctx, cred.GetID()); err != nil {
+		t.Fatalf("delete password row: %v", err)
+	}
+
+	_, _, _, err = svc.VerifyPassword(ctx, "alice@example.com", "hunter2")
+	if !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("orphan credential row: got %v, want ErrInvalidPassword", err)
+	}
+}
+
+func TestPasswordEvents_NoHashInJSON(t *testing.T) {
+	t.Parallel()
+
+	const secret = "$2a$10$top-secret-hash-should-never-appear"
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", secret)
+	if err != nil {
+		t.Fatalf("With: %v", err)
+	}
+	if err := pc.Update("bcrypt", "$2a$12$another-secret"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	for _, evt := range pc.GetUncommittedEvents() {
+		raw, err := json.Marshal(evt.Payload)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if bytes.Contains(raw, []byte("$2a$")) {
+			t.Errorf("event JSON contains a bcrypt-hash substring: %s -> %s", evt.EventType, raw)
+		}
+	}
+
+	// The redacted Stringer must not leak the hash either.
+	if str := pc.String(); strings.Contains(str, "$2a$") {
+		t.Errorf("PasswordCredential.String() leaks hash: %s", str)
+	}
+}
+
+func TestDummyHash_TracksConfiguredCost(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Service with a non-default bcrypt cost. The unknown-email branch
+	// should run a compare against a hash AT THE CONFIGURED COST so timing
+	// matches a real failed login. We can't directly assert cost from the
+	// service (private field), but we can prove the timing shield ran by
+	// confirming the unknown-email path returns ErrInvalidPassword
+	// (regression: a malformed dummy returned the same error trivially
+	// fast — that's covered by TestVerifyPassword_UnknownEmail's
+	// configured-cost variant below).
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost+1),
+	)
+
+	if _, _, _, err := svc.VerifyPassword(ctx, "nobody@example.com", "anything"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("expected ErrInvalidPassword, got %v", err)
+	}
+	// Second call exercises the cached dummy hash; both must succeed.
+	if _, _, _, err := svc.VerifyPassword(ctx, "nobody2@example.com", "anything"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("expected ErrInvalidPassword on cached path, got %v", err)
 	}
 }
 

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -347,13 +347,115 @@ func TestUpdatePassword_WithEventStore(t *testing.T) {
 	// UpdatePassword on a rehydrated aggregate must not conflict with the
 	// optimistic-concurrency check on the event store — see the comment in
 	// UpdatePassword. This test fails with "expected version 0" if the
-	// implementation regresses to using a UoW.
+	// implementation regresses to using a UoW without first reseating the
+	// aggregate's sequence number to the stream's current version.
 	if err := svc.UpdatePassword(ctx, agent.GetID(), "hunter2", "newpass1"); err != nil {
 		t.Fatalf("UpdatePassword with event store: %v", err)
 	}
 
 	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "newpass1"); err != nil {
 		t.Errorf("verify after update failed: %v", err)
+	}
+
+	// Regression: the PasswordUpdated event must reach the event store so
+	// password rotations remain auditable. A previous implementation
+	// dropped the event by calling ClearUncommittedEvents().
+	credRepo := gorminfra.NewCredentialRepository(db)
+	cred, err := credRepo.FindByProvider(ctx, entities.ProviderPassword, "alice@example.com")
+	if err != nil || cred == nil {
+		t.Fatalf("locate credential: %v %+v", err, cred)
+	}
+	pcRepo := gorminfra.NewPasswordCredentialRepository(db)
+	pc, err := pcRepo.FindByCredentialID(ctx, cred.GetID())
+	if err != nil || pc == nil {
+		t.Fatalf("locate password credential: %v %+v", err, pc)
+	}
+	events, err := store.GetEvents(ctx, pc.GetID())
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	var sawUpdated bool
+	for _, ev := range events {
+		if ev.EventType == entities.EventTypePasswordUpdated {
+			sawUpdated = true
+		}
+	}
+	if !sawUpdated {
+		t.Errorf("event store missing %q event for aggregate %s; got %d events", entities.EventTypePasswordUpdated, pc.GetID(), len(events))
+	}
+}
+
+// TestVerifyPassword_DoesNotTouchRotatedAt is a regression test for the
+// GORM auto-update timestamp footgun: PasswordCredentialModel previously
+// named its rotated-at column field UpdatedAt, which GORM silently bumped
+// on every Save (including the LastVerifiedAt update done after a
+// successful verify), corrupting the domain meaning of UpdatedAt() as
+// "password rotated at."
+func TestVerifyPassword_DoesNotTouchRotatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, db := newSQLiteDeps(t)
+	pcRepo := gorminfra.NewPasswordCredentialRepository(db)
+	credRepo := gorminfra.NewCredentialRepository(db)
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+	cred, err := credRepo.FindByProvider(ctx, entities.ProviderPassword, "alice@example.com")
+	if err != nil || cred == nil {
+		t.Fatalf("locate credential: %v %+v", err, cred)
+	}
+	before, err := pcRepo.FindByCredentialID(ctx, cred.GetID())
+	if err != nil || before == nil {
+		t.Fatalf("locate password credential: %v %+v", err, before)
+	}
+	rotatedBefore := before.UpdatedAt()
+
+	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "hunter2"); err != nil {
+		t.Fatalf("VerifyPassword: %v", err)
+	}
+
+	after, err := pcRepo.FindByCredentialID(ctx, cred.GetID())
+	if err != nil || after == nil {
+		t.Fatalf("locate password credential after verify: %v %+v", err, after)
+	}
+	if !after.UpdatedAt().Equal(rotatedBefore) {
+		t.Errorf("VerifyPassword bumped UpdatedAt (rotated_at): before=%s after=%s", rotatedBefore, after.UpdatedAt())
+	}
+	// LastVerifiedAt should advance, confirming the row was actually
+	// written and we are not testing a no-op.
+	if !after.LastVerifiedAt().After(before.LastVerifiedAt()) {
+		t.Errorf("expected LastVerifiedAt to advance after verify: before=%s after=%s", before.LastVerifiedAt(), after.LastVerifiedAt())
+	}
+}
+
+// TestImportPasswordCredential_RejectsMalformedHash covers the validation
+// gap where any non-empty string was accepted as a bcrypt hash, which
+// would silently turn into ErrInvalidPassword on every future login.
+func TestImportPasswordCredential_RejectsMalformedHash(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, _ := newSQLiteDeps(t)
+
+	owner, _, ownerAccount, err := svc.RegisterPassword(ctx, "owner@example.com", "Owner", "ownerpass")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cases := []string{
+		"not-a-bcrypt-hash",
+		"$2a$10$abc",          // truncated
+		"plaintext-password", // obvious migration mistake
+	}
+	for _, badHash := range cases {
+		err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", badHash, owner.GetID(), ownerAccount.GetID())
+		if err == nil {
+			t.Errorf("ImportPasswordCredential(%q) accepted malformed hash; want error", badHash)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid bcrypt hash") {
+			t.Errorf("ImportPasswordCredential(%q) error = %v, want invalid-bcrypt-hash", badHash, err)
+		}
 	}
 }
 

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -1,0 +1,394 @@
+package application_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	gorminfra "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/database/gorm"
+	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
+	esinfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
+	"github.com/glebarez/sqlite"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func newSQLiteAuthService(t *testing.T) *application.DefaultAuthenticationService {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		// Lower bcrypt cost to keep the test fast; production callers should
+		// stick to bcrypt.DefaultCost.
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+}
+
+func TestRegisterAndVerifyPassword(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	agent, cred, account, err := svc.RegisterPassword(ctx, "Alice@example.com", "Alice", "hunter2")
+	if err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+	if agent == nil || cred == nil || account == nil {
+		t.Fatalf("expected non-nil agent/cred/account, got %v %v %v", agent, cred, account)
+	}
+	if cred.Provider() != entities.ProviderPassword {
+		t.Errorf("Provider() = %q, want %q", cred.Provider(), entities.ProviderPassword)
+	}
+	if cred.ProviderUserID() != "alice@example.com" {
+		t.Errorf("ProviderUserID() = %q, want lowercased email", cred.ProviderUserID())
+	}
+
+	// Successful verify with matching password.
+	verifiedAgent, verifiedCred, verifiedAccount, err := svc.VerifyPassword(ctx, "alice@example.com", "hunter2")
+	if err != nil {
+		t.Fatalf("VerifyPassword (success): %v", err)
+	}
+	if verifiedAgent.GetID() != agent.GetID() {
+		t.Errorf("agent ID = %q, want %q", verifiedAgent.GetID(), agent.GetID())
+	}
+	if verifiedCred.GetID() != cred.GetID() {
+		t.Errorf("cred ID = %q, want %q", verifiedCred.GetID(), cred.GetID())
+	}
+	if verifiedAccount == nil || verifiedAccount.GetID() != account.GetID() {
+		t.Errorf("account mismatch: %+v vs %+v", verifiedAccount, account)
+	}
+
+	// Email is normalized — different case still matches.
+	if _, _, _, err := svc.VerifyPassword(ctx, "ALICE@EXAMPLE.COM", "hunter2"); err != nil {
+		t.Errorf("VerifyPassword with uppercase email failed: %v", err)
+	}
+}
+
+func TestVerifyPassword_WrongPassword(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+
+	_, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "wrong-password")
+	if !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("error = %v, want ErrInvalidPassword", err)
+	}
+}
+
+func TestVerifyPassword_UnknownEmail(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	_, _, _, err := svc.VerifyPassword(ctx, "ghost@example.com", "anything")
+	if !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("error = %v, want ErrInvalidPassword (not a different sentinel — anti-enumeration)", err)
+	}
+}
+
+func TestRegisterPassword_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	_, _, _, err := svc.RegisterPassword(ctx, "ALICE@example.com", "Alice2", "hunter3")
+	if !errors.Is(err, application.ErrEmailAlreadyTaken) {
+		t.Errorf("error = %v, want ErrEmailAlreadyTaken", err)
+	}
+}
+
+func TestUpdatePassword(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	agent, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2")
+	if err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+
+	if err := svc.UpdatePassword(ctx, agent.GetID(), "wrong", "newpass1"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("UpdatePassword with wrong old password = %v, want ErrInvalidPassword", err)
+	}
+
+	if err := svc.UpdatePassword(ctx, agent.GetID(), "hunter2", "newpass1"); err != nil {
+		t.Fatalf("UpdatePassword: %v", err)
+	}
+	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "hunter2"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("expected old password to no longer verify, got %v", err)
+	}
+	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "newpass1"); err != nil {
+		t.Errorf("new password failed to verify: %v", err)
+	}
+}
+
+func TestUpdatePassword_MissingPasswordCredential(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	if err := svc.UpdatePassword(ctx, "missing-agent", "old", "new"); !errors.Is(err, application.ErrPasswordCredentialMissing) {
+		t.Errorf("error = %v, want ErrPasswordCredentialMissing", err)
+	}
+}
+
+func TestImportPasswordCredential(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	// Seed an agent + personal account using RegisterPassword for a
+	// different email so we have foreign keys to bind the import to.
+	owner, _, ownerAccount, err := svc.RegisterPassword(ctx, "owner@example.com", "Owner", "ownerpass")
+	if err != nil {
+		t.Fatalf("seed RegisterPassword: %v", err)
+	}
+
+	// Hash a legacy password externally; bcrypt MinCost keeps the test fast.
+	legacyHash, err := bcrypt.GenerateFromPassword([]byte("legacy-pass"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+
+	// Import a password credential against the existing agent.
+	if err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(legacyHash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("ImportPasswordCredential: %v", err)
+	}
+
+	// VerifyPassword against the imported hash succeeds without rehashing.
+	verifiedAgent, _, _, err := svc.VerifyPassword(ctx, "legacy@example.com", "legacy-pass")
+	if err != nil {
+		t.Fatalf("VerifyPassword (imported): %v", err)
+	}
+	if verifiedAgent.GetID() != owner.GetID() {
+		t.Errorf("imported credential resolved to agent %q, want %q", verifiedAgent.GetID(), owner.GetID())
+	}
+
+	// Idempotent: re-importing returns nil without error.
+	if err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(legacyHash), owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Errorf("re-import should be idempotent, got %v", err)
+	}
+}
+
+func TestImportPasswordCredential_UnknownAgent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newSQLiteAuthService(t)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("legacy-pass"), bcrypt.MinCost)
+	err := svc.ImportPasswordCredential(ctx, "legacy@example.com", "Legacy", string(hash), "agent-does-not-exist", "")
+	if err == nil || !strings.Contains(err.Error(), "agent agent-does-not-exist not found") {
+		t.Errorf("expected agent-not-found error, got %v", err)
+	}
+}
+
+func TestVerifyPassword_DeactivatedCredential(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	credRepo := gorminfra.NewCredentialRepository(db)
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		credRepo,
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+
+	_, cred, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2")
+	if err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+	if err := cred.Deactivate(); err != nil {
+		t.Fatalf("Deactivate: %v", err)
+	}
+	if err := credRepo.Save(ctx, cred); err != nil {
+		t.Fatalf("Save deactivated credential: %v", err)
+	}
+
+	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "hunter2"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("expected ErrInvalidPassword for deactivated credential, got %v", err)
+	}
+}
+
+func TestRegisterPasswordThenIssueJWT(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	jwtSvc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(rsaKey))
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithJWTService(jwtSvc),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+
+	agent, _, account, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2")
+	if err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+
+	verifiedAgent, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "hunter2")
+	if err != nil {
+		t.Fatalf("VerifyPassword: %v", err)
+	}
+	if verifiedAgent.GetID() != agent.GetID() {
+		t.Fatalf("agent mismatch")
+	}
+
+	token, err := svc.IssueIdentityToken(ctx, verifiedAgent, account.GetID())
+	if err != nil {
+		t.Fatalf("IssueIdentityToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty JWT")
+	}
+	claims, err := jwtSvc.ValidateToken(ctx, token)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.AgentID != agent.GetID() {
+		t.Errorf("claims.AgentID = %q, want %q", claims.AgentID, agent.GetID())
+	}
+}
+
+func TestUpdatePassword_WithEventStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := esinfra.NewGormEventStore(db)
+	if err != nil {
+		t.Fatalf("event store: %v", err)
+	}
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithEventStore(store),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+
+	agent, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2")
+	if err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+
+	// UpdatePassword on a rehydrated aggregate must not conflict with the
+	// optimistic-concurrency check on the event store — see the comment in
+	// UpdatePassword. This test fails with "expected version 0" if the
+	// implementation regresses to using a UoW.
+	if err := svc.UpdatePassword(ctx, agent.GetID(), "hunter2", "newpass1"); err != nil {
+		t.Fatalf("UpdatePassword with event store: %v", err)
+	}
+
+	if _, _, _, err := svc.VerifyPassword(ctx, "alice@example.com", "newpass1"); err != nil {
+		t.Errorf("verify after update failed: %v", err)
+	}
+}
+
+func TestDummyBcryptHash_IsValid(t *testing.T) {
+	t.Parallel()
+	// Asserts that the constant in authentication_service.go parses as a
+	// real bcrypt hash so verifyPassword performs the timing-equalizing
+	// CompareHashAndPassword cycle. The expected error is the mismatch
+	// sentinel — not a parse/format error.
+	svc := newSQLiteAuthService(t)
+	ctx := context.Background()
+
+	// Calling VerifyPassword with no registered credentials hits the
+	// dummy-hash branch. We do not assert on timing, just on the returned
+	// error: it must be ErrInvalidPassword (not wrapped/unrelated).
+	if _, _, _, err := svc.VerifyPassword(ctx, "ghost@example.com", "any"); !errors.Is(err, application.ErrInvalidPassword) {
+		t.Errorf("error = %v, want ErrInvalidPassword (dummy hash may be malformed)", err)
+	}
+}
+
+func TestPasswordSupportNotConfigured(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Service WITHOUT WithPasswordCredentialRepository.
+	svc, _ := newTestService()
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "a@b.com", "A", "p"); !errors.Is(err, application.ErrPasswordSupportNotConfigured) {
+		t.Errorf("RegisterPassword: %v", err)
+	}
+	if _, _, _, err := svc.VerifyPassword(ctx, "a@b.com", "p"); !errors.Is(err, application.ErrPasswordSupportNotConfigured) {
+		t.Errorf("VerifyPassword: %v", err)
+	}
+	if err := svc.ImportPasswordCredential(ctx, "a@b.com", "A", "h", "agent", ""); !errors.Is(err, application.ErrPasswordSupportNotConfigured) {
+		t.Errorf("ImportPasswordCredential: %v", err)
+	}
+	if err := svc.UpdatePassword(ctx, "agent", "old", "new"); !errors.Is(err, application.ErrPasswordSupportNotConfigured) {
+		t.Errorf("UpdatePassword: %v", err)
+	}
+}

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	gorminfra "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/database/gorm"
 	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
 	esinfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
@@ -695,5 +696,122 @@ func TestPasswordSupportNotConfigured(t *testing.T) {
 	}
 	if err := svc.UpdatePassword(ctx, "agent", "old", "new"); !errors.Is(err, application.ErrPasswordSupportNotConfigured) {
 		t.Errorf("UpdatePassword: %v", err)
+	}
+}
+
+// blindCredentialRepo wraps a real CredentialRepository but always reports
+// "no existing credential" from FindByProvider. This deterministically
+// simulates the TOCTOU race where two concurrent RegisterPassword calls
+// both pass the pre-check and the second one hits the unique index on
+// (provider, provider_user_id) at credentials.Save.
+type blindCredentialRepo struct {
+	repositories.CredentialRepository
+}
+
+func (b *blindCredentialRepo) FindByProvider(ctx context.Context, provider, providerUserID string) (*entities.Credential, error) {
+	return nil, nil
+}
+
+func TestRegisterPassword_DuplicateOnSaveTranslates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	credRepo := gorminfra.NewCredentialRepository(db)
+
+	// Seed an existing password credential for alice@example.com so the
+	// second register's Save will violate the unique index.
+	seed := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		credRepo,
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+	if _, _, _, err := seed.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("seed RegisterPassword: %v", err)
+	}
+
+	// New service whose CredentialRepository always lies on FindByProvider —
+	// the pre-check passes, Save runs, the unique index fires.
+	racy := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		&blindCredentialRepo{CredentialRepository: credRepo},
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+
+	_, _, _, err = racy.RegisterPassword(ctx, "alice@example.com", "Alice2", "hunter3")
+	if !errors.Is(err, application.ErrEmailAlreadyTaken) {
+		t.Fatalf("error = %v, want ErrEmailAlreadyTaken (dup-key was not translated)", err)
+	}
+}
+
+func TestImportPasswordCredential_DuplicateOnSaveIsIdempotent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	credRepo := gorminfra.NewCredentialRepository(db)
+
+	seed := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		credRepo,
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+	owner, _, ownerAccount, err := seed.RegisterPassword(ctx, "owner@example.com", "Owner", "ownerpass")
+	if err != nil {
+		t.Fatalf("seed RegisterPassword: %v", err)
+	}
+	// Seed a real credential for the email we'll import; the racy
+	// service's blind FindByProvider will skip the idempotent pre-check
+	// and fall through to credentials.Save where the unique index fires.
+	if err := seed.ImportPasswordCredential(ctx,
+		"legacy@example.com", "Legacy",
+		"$2a$04$abcdefghijklmnopqrstuuwOl4ZJN8xpZ/Hf1jZQp7m/0ePI1ZGGy",
+		owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("seed ImportPasswordCredential: %v", err)
+	}
+
+	racy := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		&blindCredentialRepo{CredentialRepository: credRepo},
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+	)
+
+	if err := racy.ImportPasswordCredential(ctx,
+		"legacy@example.com", "Legacy",
+		"$2a$04$abcdefghijklmnopqrstuuwOl4ZJN8xpZ/Hf1jZQp7m/0ePI1ZGGy",
+		owner.GetID(), ownerAccount.GetID()); err != nil {
+		t.Fatalf("ImportPasswordCredential after dup-key race must be idempotent (nil), got %v", err)
 	}
 }

--- a/pkg/auth/application/password_hasher.go
+++ b/pkg/auth/application/password_hasher.go
@@ -1,0 +1,50 @@
+package application
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ErrInvalidPassword is returned when a plaintext password fails to match
+// the stored hash. To avoid revealing which emails are registered,
+// VerifyPassword also returns this sentinel when no matching credential is
+// found at all.
+var ErrInvalidPassword = errors.New("authentication: invalid password")
+
+// hashPassword produces an algorithm identifier and hash for the given
+// plaintext using bcrypt at the requested cost. cost <= 0 selects
+// bcrypt.DefaultCost.
+func hashPassword(plaintext string, cost int) (algorithm, hash string, err error) {
+	if cost <= 0 {
+		cost = bcrypt.DefaultCost
+	}
+	out, err := bcrypt.GenerateFromPassword([]byte(plaintext), cost)
+	if err != nil {
+		return "", "", fmt.Errorf("bcrypt hash: %w", err)
+	}
+	return entities.PasswordAlgorithmBcrypt, string(out), nil
+}
+
+// verifyPassword compares plaintext against the stored hash for the named
+// algorithm. Returns entities.ErrInvalidPassword on mismatch and a wrapped
+// error if the algorithm is unsupported. Comparison errors other than
+// mismatch (e.g. corrupt hash) are surfaced as-is so the caller can
+// distinguish them in logs without leaking detail to end users.
+func verifyPassword(algorithm, hash, plaintext string) error {
+	switch algorithm {
+	case entities.PasswordAlgorithmBcrypt:
+		err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(plaintext))
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			return ErrInvalidPassword
+		}
+		return fmt.Errorf("bcrypt compare: %w", err)
+	default:
+		return fmt.Errorf("unsupported password algorithm: %q", algorithm)
+	}
+}

--- a/pkg/auth/application/password_hasher.go
+++ b/pkg/auth/application/password_hasher.go
@@ -29,10 +29,10 @@ func hashPassword(plaintext string, cost int) (algorithm, hash string, err error
 }
 
 // verifyPassword compares plaintext against the stored hash for the named
-// algorithm. Returns entities.ErrInvalidPassword on mismatch and a wrapped
-// error if the algorithm is unsupported. Comparison errors other than
-// mismatch (e.g. corrupt hash) are surfaced as-is so the caller can
-// distinguish them in logs without leaking detail to end users.
+// algorithm. Returns ErrInvalidPassword on mismatch, and a wrapped error
+// for any other failure (corrupt hash, unsupported algorithm) so the
+// caller can log the detail internally while still reporting only
+// ErrInvalidPassword to the end user.
 func verifyPassword(algorithm, hash, plaintext string) error {
 	switch algorithm {
 	case entities.PasswordAlgorithmBcrypt:

--- a/pkg/auth/domain/entities/ontology.go
+++ b/pkg/auth/domain/entities/ontology.go
@@ -108,6 +108,19 @@ const (
 	RoleAdmin  = "admin"
 )
 
+// Built-in credential providers.
+const (
+	// ProviderPassword identifies username/password credentials. The
+	// credential's provider_user_id is the lowercased email; the bcrypt
+	// hash lives in the linked PasswordCredential row.
+	ProviderPassword = "password"
+)
+
+// Password hashing algorithms stored on a PasswordCredential row.
+const (
+	PasswordAlgorithmBcrypt = "bcrypt"
+)
+
 // Agent status constants.
 const (
 	AgentStatusActive      = "active"
@@ -124,13 +137,14 @@ const (
 
 // Event type patterns for LIKE queries.
 const (
-	PatternAgent      = "Agent.%"
-	PatternPolicy     = "Policy.%"
-	PatternRole       = "Role.%"
-	PatternAccount    = "Account.%"
-	PatternCredential = "Credential.%"
-	PatternSession    = "Session.%"
-	PatternInvite     = "Invite.%"
+	PatternAgent              = "Agent.%"
+	PatternPolicy             = "Policy.%"
+	PatternRole               = "Role.%"
+	PatternAccount            = "Account.%"
+	PatternCredential         = "Credential.%"
+	PatternPasswordCredential = "PasswordCredential.%"
+	PatternSession            = "Session.%"
+	PatternInvite             = "Invite.%"
 )
 
 // Event type constants for auth domain events.
@@ -171,6 +185,9 @@ const (
 	EventTypeCredentialUsed        = "Credential.Used"
 	EventTypeCredentialDeactivated = "Credential.Deactivated"
 	EventTypeCredentialReactivated = "Credential.Reactivated"
+
+	EventTypePasswordCredentialCreated = "PasswordCredential.Created"
+	EventTypePasswordUpdated           = "PasswordCredential.Updated"
 
 	EventTypeSessionCreated       = "Session.Created"
 	EventTypeSessionTouched       = "Session.Touched"

--- a/pkg/auth/domain/entities/password_credential.go
+++ b/pkg/auth/domain/entities/password_credential.go
@@ -54,6 +54,21 @@ func (p *PasswordCredential) With(id, credentialID, algorithm, hash string) (*Pa
 	return p, nil
 }
 
+// String redacts the Hash so the aggregate is safe to log via %v / %+v.
+// Callers needing the raw hash must use Hash() explicitly.
+func (p *PasswordCredential) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"PasswordCredential{ID:%s CredentialID:%s Algorithm:%s Hash:[REDACTED]}",
+		p.GetID(), p.credentialID, p.algorithm,
+	)
+}
+
+// GoString mirrors String so %#v also redacts the hash.
+func (p *PasswordCredential) GoString() string { return p.String() }
+
 // CredentialID returns the ID of the parent Credential aggregate.
 func (p *PasswordCredential) CredentialID() string { return p.credentialID }
 

--- a/pkg/auth/domain/entities/password_credential.go
+++ b/pkg/auth/domain/entities/password_credential.go
@@ -1,0 +1,140 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/ddd"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+)
+
+// PasswordCredential is an event-sourced aggregate that stores the hashed
+// secret for a Credential of provider="password". It is linked 1:1 to a
+// Credential row by CredentialID; the hash itself is persisted on this
+// aggregate's row, never on the parent Credential and never on any event
+// payload.
+type PasswordCredential struct {
+	*ddd.BaseEntity
+	credentialID   string
+	algorithm      string
+	hash           string
+	createdAt      time.Time
+	updatedAt      time.Time
+	lastVerifiedAt time.Time
+}
+
+// With initializes a new PasswordCredential with the given parameters.
+// The hash must already be computed by the caller.
+func (p *PasswordCredential) With(id, credentialID, algorithm, hash string) (*PasswordCredential, error) {
+	if id == "" {
+		return nil, fmt.Errorf("password credential ID cannot be empty")
+	}
+	if credentialID == "" {
+		return nil, fmt.Errorf("credential ID cannot be empty")
+	}
+	if algorithm == "" {
+		return nil, fmt.Errorf("algorithm cannot be empty")
+	}
+	if hash == "" {
+		return nil, fmt.Errorf("hash cannot be empty")
+	}
+
+	p.BaseEntity = ddd.NewBaseEntity(id)
+	p.credentialID = credentialID
+	p.algorithm = algorithm
+	p.hash = hash
+	p.createdAt = time.Now()
+	p.updatedAt = p.createdAt
+
+	event := new(PasswordCredentialCreated).With(id, credentialID, algorithm, p.createdAt)
+	if err := p.RecordEvent(event, event.EventType()); err != nil {
+		return nil, fmt.Errorf("failed to record PasswordCredential.Created event: %w", err)
+	}
+	return p, nil
+}
+
+// CredentialID returns the ID of the parent Credential aggregate.
+func (p *PasswordCredential) CredentialID() string { return p.credentialID }
+
+// Algorithm returns the hashing algorithm identifier (e.g. "bcrypt").
+func (p *PasswordCredential) Algorithm() string { return p.algorithm }
+
+// Hash returns the stored hash. Callers should never log or expose this
+// value; it exists only so persistence and verification helpers can read
+// the row contents.
+func (p *PasswordCredential) Hash() string { return p.hash }
+
+// CreatedAt returns when the password credential was created.
+func (p *PasswordCredential) CreatedAt() time.Time { return p.createdAt }
+
+// UpdatedAt returns when the password was last rotated (or createdAt if
+// never updated).
+func (p *PasswordCredential) UpdatedAt() time.Time { return p.updatedAt }
+
+// LastVerifiedAt returns the last successful verification timestamp.
+// Zero if the credential has never been verified.
+func (p *PasswordCredential) LastVerifiedAt() time.Time { return p.lastVerifiedAt }
+
+// Restore restores a PasswordCredential from database values without
+// recording events.
+func (p *PasswordCredential) Restore(id, credentialID, algorithm, hash string, createdAt, updatedAt, lastVerifiedAt time.Time) error {
+	if id == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
+	if credentialID == "" {
+		return fmt.Errorf("credential ID cannot be empty")
+	}
+	p.BaseEntity = ddd.NewBaseEntity(id)
+	p.credentialID = credentialID
+	p.algorithm = algorithm
+	p.hash = hash
+	p.createdAt = createdAt
+	p.updatedAt = updatedAt
+	p.lastVerifiedAt = lastVerifiedAt
+	return nil
+}
+
+// Update rotates the stored hash and emits a PasswordUpdated event.
+func (p *PasswordCredential) Update(algorithm, hash string) error {
+	if algorithm == "" {
+		return fmt.Errorf("algorithm cannot be empty")
+	}
+	if hash == "" {
+		return fmt.Errorf("hash cannot be empty")
+	}
+	p.algorithm = algorithm
+	p.hash = hash
+	p.updatedAt = time.Now()
+
+	event := new(PasswordUpdated).With(p.GetID(), p.credentialID, algorithm, p.updatedAt)
+	return p.RecordEvent(event, event.EventType())
+}
+
+// MarkVerified records a successful verification. This is a projection-only
+// state mutation and does not emit an event — bumping last_verified_at on
+// every login would amplify event volume without proportional value.
+func (p *PasswordCredential) MarkVerified() {
+	p.lastVerifiedAt = time.Now()
+}
+
+// ApplyEvent applies a domain event to reconstruct the aggregate state.
+func (p *PasswordCredential) ApplyEvent(ctx context.Context, envelope domain.EventEnvelope[any]) error {
+	if err := p.BaseEntity.ApplyEvent(ctx, envelope); err != nil {
+		return fmt.Errorf("base entity apply event failed: %w", err)
+	}
+
+	switch payload := envelope.Payload.(type) {
+	case PasswordCredentialCreated:
+		p.credentialID = payload.CredentialID
+		p.algorithm = payload.Algorithm
+		p.createdAt = payload.CreatedAt
+		p.updatedAt = payload.CreatedAt
+	case PasswordUpdated:
+		p.algorithm = payload.Algorithm
+		p.updatedAt = payload.UpdatedAt
+	default:
+		return fmt.Errorf("unknown event type: %T", envelope.Payload)
+	}
+	return nil
+}

--- a/pkg/auth/domain/entities/password_credential_events.go
+++ b/pkg/auth/domain/entities/password_credential_events.go
@@ -1,0 +1,53 @@
+package entities
+
+import "time"
+
+// PasswordCredentialCreated represents the creation of a password credential
+// linked to a Credential aggregate. The hash and plaintext are deliberately
+// excluded; only metadata is carried so events can be safely persisted and
+// dispatched.
+type PasswordCredentialCreated struct {
+	PasswordCredentialID string    `json:"password_credential_id"`
+	CredentialID         string    `json:"credential_id"`
+	Algorithm            string    `json:"algorithm"`
+	CreatedAt            time.Time `json:"created_at"`
+}
+
+// With creates a new PasswordCredentialCreated event.
+func (e PasswordCredentialCreated) With(passwordCredentialID, credentialID, algorithm string, createdAt time.Time) PasswordCredentialCreated {
+	return PasswordCredentialCreated{
+		PasswordCredentialID: passwordCredentialID,
+		CredentialID:         credentialID,
+		Algorithm:            algorithm,
+		CreatedAt:            createdAt,
+	}
+}
+
+// EventType returns the event type name.
+func (e PasswordCredentialCreated) EventType() string {
+	return EventTypePasswordCredentialCreated
+}
+
+// PasswordUpdated represents a password rotation on a PasswordCredential.
+// Carries only metadata — never the hash or plaintext.
+type PasswordUpdated struct {
+	PasswordCredentialID string    `json:"password_credential_id"`
+	CredentialID         string    `json:"credential_id"`
+	Algorithm            string    `json:"algorithm"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+// With creates a new PasswordUpdated event.
+func (e PasswordUpdated) With(passwordCredentialID, credentialID, algorithm string, updatedAt time.Time) PasswordUpdated {
+	return PasswordUpdated{
+		PasswordCredentialID: passwordCredentialID,
+		CredentialID:         credentialID,
+		Algorithm:            algorithm,
+		UpdatedAt:            updatedAt,
+	}
+}
+
+// EventType returns the event type name.
+func (e PasswordUpdated) EventType() string {
+	return EventTypePasswordUpdated
+}

--- a/pkg/auth/domain/entities/password_credential_test.go
+++ b/pkg/auth/domain/entities/password_credential_test.go
@@ -1,0 +1,235 @@
+package entities_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+)
+
+func TestPasswordCredential_With(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		id           string
+		credentialID string
+		algorithm    string
+		hash         string
+		wantErr      bool
+	}{
+		{name: "creates password credential", id: "pc-1", credentialID: "cred-1", algorithm: "bcrypt", hash: "$2a$10$abc"},
+		{name: "fails with empty id", id: "", credentialID: "cred-1", algorithm: "bcrypt", hash: "$2a$10$abc", wantErr: true},
+		{name: "fails with empty credential id", id: "pc-1", credentialID: "", algorithm: "bcrypt", hash: "$2a$10$abc", wantErr: true},
+		{name: "fails with empty algorithm", id: "pc-1", credentialID: "cred-1", algorithm: "", hash: "$2a$10$abc", wantErr: true},
+		{name: "fails with empty hash", id: "pc-1", credentialID: "cred-1", algorithm: "bcrypt", hash: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pc, err := new(entities.PasswordCredential).With(tt.id, tt.credentialID, tt.algorithm, tt.hash)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if pc.GetID() != tt.id {
+				t.Errorf("GetID() = %q, want %q", pc.GetID(), tt.id)
+			}
+			if pc.CredentialID() != tt.credentialID {
+				t.Errorf("CredentialID() = %q, want %q", pc.CredentialID(), tt.credentialID)
+			}
+			if pc.Algorithm() != tt.algorithm {
+				t.Errorf("Algorithm() = %q, want %q", pc.Algorithm(), tt.algorithm)
+			}
+			if pc.Hash() != tt.hash {
+				t.Errorf("Hash() = %q, want %q", pc.Hash(), tt.hash)
+			}
+			if pc.CreatedAt().IsZero() {
+				t.Error("expected non-zero CreatedAt")
+			}
+
+			events := pc.GetUncommittedEvents()
+			if len(events) != 1 {
+				t.Fatalf("expected 1 uncommitted event, got %d", len(events))
+			}
+			if events[0].EventType != entities.EventTypePasswordCredentialCreated {
+				t.Errorf("event type = %q, want %q", events[0].EventType, entities.EventTypePasswordCredentialCreated)
+			}
+
+			payload, ok := events[0].Payload.(entities.PasswordCredentialCreated)
+			if !ok {
+				t.Fatalf("expected PasswordCredentialCreated payload, got %T", events[0].Payload)
+			}
+			if payload.PasswordCredentialID != tt.id {
+				t.Errorf("PasswordCredentialID = %q, want %q", payload.PasswordCredentialID, tt.id)
+			}
+			if payload.CredentialID != tt.credentialID {
+				t.Errorf("CredentialID = %q, want %q", payload.CredentialID, tt.credentialID)
+			}
+			if payload.Algorithm != tt.algorithm {
+				t.Errorf("Algorithm = %q, want %q", payload.Algorithm, tt.algorithm)
+			}
+		})
+	}
+}
+
+func TestPasswordCredential_EventCarriesNoSecrets(t *testing.T) {
+	t.Parallel()
+
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$top-secret-hash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := pc.Update("bcrypt", "$2a$10$another-secret"); err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+
+	for _, evt := range pc.GetUncommittedEvents() {
+		switch p := evt.Payload.(type) {
+		case entities.PasswordCredentialCreated:
+			// Verify struct shape carries only metadata fields. The presence
+			// of any string field whose value matches the hash would mean a
+			// leak; we rely on the type system to keep the surface minimal,
+			// and assert on the absence of any "Hash" field by inspecting
+			// the documented public fields.
+			if p.Algorithm == "" {
+				t.Error("expected algorithm set")
+			}
+		case entities.PasswordUpdated:
+			if p.Algorithm == "" {
+				t.Error("expected algorithm set")
+			}
+		default:
+			t.Fatalf("unexpected event type: %T", evt.Payload)
+		}
+	}
+}
+
+func TestPasswordCredential_Update(t *testing.T) {
+	t.Parallel()
+
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	originalUpdated := pc.UpdatedAt()
+	time.Sleep(2 * time.Millisecond)
+
+	if err := pc.Update("bcrypt", "$2a$12$new"); err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+	if pc.Hash() != "$2a$12$new" {
+		t.Errorf("Hash() = %q, want $2a$12$new", pc.Hash())
+	}
+	if !pc.UpdatedAt().After(originalUpdated) {
+		t.Error("expected UpdatedAt to advance")
+	}
+
+	events := pc.GetUncommittedEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].EventType != entities.EventTypePasswordUpdated {
+		t.Errorf("event[1].EventType = %q, want %q", events[1].EventType, entities.EventTypePasswordUpdated)
+	}
+	payload, ok := events[1].Payload.(entities.PasswordUpdated)
+	if !ok {
+		t.Fatalf("expected PasswordUpdated payload, got %T", events[1].Payload)
+	}
+	if payload.Algorithm != "bcrypt" {
+		t.Errorf("Algorithm = %q, want bcrypt", payload.Algorithm)
+	}
+
+	if err := pc.Update("", "$2a$12$xyz"); err == nil {
+		t.Error("expected error for empty algorithm")
+	}
+	if err := pc.Update("bcrypt", ""); err == nil {
+		t.Error("expected error for empty hash")
+	}
+}
+
+func TestPasswordCredential_MarkVerified(t *testing.T) {
+	t.Parallel()
+
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pc.LastVerifiedAt().IsZero() {
+		t.Error("expected zero LastVerifiedAt before MarkVerified")
+	}
+
+	before := time.Now()
+	pc.MarkVerified()
+	if pc.LastVerifiedAt().Before(before) {
+		t.Error("expected LastVerifiedAt to be updated")
+	}
+
+	// MarkVerified is intentionally event-free.
+	if got := len(pc.GetUncommittedEvents()); got != 1 {
+		t.Errorf("expected exactly 1 uncommitted event after MarkVerified, got %d", got)
+	}
+}
+
+func TestPasswordCredential_Restore(t *testing.T) {
+	t.Parallel()
+
+	pc := &entities.PasswordCredential{}
+	now := time.Now()
+	if err := pc.Restore("pc-1", "cred-1", "bcrypt", "$2a$10$abc", now, now, time.Time{}); err != nil {
+		t.Fatalf("Restore() error: %v", err)
+	}
+	if pc.GetID() != "pc-1" {
+		t.Errorf("GetID() = %q, want pc-1", pc.GetID())
+	}
+	if got := len(pc.GetUncommittedEvents()); got != 0 {
+		t.Errorf("expected 0 uncommitted events after Restore, got %d", got)
+	}
+	if err := (&entities.PasswordCredential{}).Restore("", "cred-1", "bcrypt", "$2a$10$abc", now, now, time.Time{}); err == nil {
+		t.Error("expected error for empty id")
+	}
+	if err := (&entities.PasswordCredential{}).Restore("pc-1", "", "bcrypt", "$2a$10$abc", now, now, time.Time{}); err == nil {
+		t.Error("expected error for empty credential id")
+	}
+}
+
+func TestPasswordCredential_ApplyEvent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := pc.Update("bcrypt", "$2a$12$new"); err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+	events := pc.GetUncommittedEvents()
+	pc.ClearUncommittedEvents()
+
+	restored := &entities.PasswordCredential{}
+	if err := restored.Restore("pc-1", "placeholder", "", "", time.Time{}, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("Restore() error: %v", err)
+	}
+	for _, evt := range events {
+		if err := restored.ApplyEvent(ctx, evt); err != nil {
+			t.Fatalf("ApplyEvent() error: %v", err)
+		}
+	}
+	if restored.CredentialID() != "cred-1" {
+		t.Errorf("CredentialID() = %q, want cred-1", restored.CredentialID())
+	}
+	if restored.Algorithm() != "bcrypt" {
+		t.Errorf("Algorithm() = %q, want bcrypt", restored.Algorithm())
+	}
+	if restored.UpdatedAt().IsZero() {
+		t.Error("expected non-zero UpdatedAt after replay")
+	}
+}

--- a/pkg/auth/domain/entities/password_credential_test.go
+++ b/pkg/auth/domain/entities/password_credential_test.go
@@ -120,7 +120,6 @@ func TestPasswordCredential_Update(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	originalUpdated := pc.UpdatedAt()
-	time.Sleep(2 * time.Millisecond)
 
 	if err := pc.Update("bcrypt", "$2a$12$new"); err != nil {
 		t.Fatalf("Update() error: %v", err)
@@ -128,8 +127,13 @@ func TestPasswordCredential_Update(t *testing.T) {
 	if pc.Hash() != "$2a$12$new" {
 		t.Errorf("Hash() = %q, want $2a$12$new", pc.Hash())
 	}
-	if !pc.UpdatedAt().After(originalUpdated) {
-		t.Error("expected UpdatedAt to advance")
+	// UpdatedAt must not regress. We avoid asserting strict advance with a
+	// sleep — coarse-resolution clocks (Windows, some CI runners) can leave
+	// time.Now() unchanged across two adjacent calls and would make the
+	// test flaky. The recorded PasswordUpdated event below already proves
+	// Update() was invoked.
+	if pc.UpdatedAt().Before(originalUpdated) {
+		t.Errorf("UpdatedAt regressed: %s -> %s", originalUpdated, pc.UpdatedAt())
 	}
 
 	events := pc.GetUncommittedEvents()

--- a/pkg/auth/domain/repositories/repositories.go
+++ b/pkg/auth/domain/repositories/repositories.go
@@ -107,6 +107,26 @@ type CredentialRepository interface {
 	FindAll(ctx context.Context, cursor string, limit int) (*PaginatedResponse[*entities.Credential], error)
 }
 
+// PasswordCredentialRepository defines the interface for PasswordCredential
+// aggregate persistence. PasswordCredentials are linked 1:1 to a Credential
+// of provider="password" by CredentialID.
+type PasswordCredentialRepository interface {
+	// Save persists the PasswordCredential aggregate state.
+	Save(ctx context.Context, credential *entities.PasswordCredential) error
+
+	// FindByID retrieves a PasswordCredential by its ID.
+	// Returns (nil, nil) if not found.
+	FindByID(ctx context.Context, id string) (*entities.PasswordCredential, error)
+
+	// FindByCredentialID retrieves the PasswordCredential linked to the
+	// given Credential. Returns (nil, nil) if not found.
+	FindByCredentialID(ctx context.Context, credentialID string) (*entities.PasswordCredential, error)
+
+	// Delete removes the PasswordCredential row linked to the given
+	// Credential. A no-op (returns nil) when no row exists.
+	Delete(ctx context.Context, credentialID string) error
+}
+
 // InviteRepository defines the interface for Invite aggregate persistence.
 type InviteRepository interface {
 	// Save persists the Invite aggregate state.

--- a/pkg/auth/domain/repositories/repositories.go
+++ b/pkg/auth/domain/repositories/repositories.go
@@ -2,9 +2,17 @@ package repositories
 
 import (
 	"context"
+	"errors"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 )
+
+// ErrDuplicateCredential is returned by CredentialRepository.Save when the
+// row violates the unique index on (provider, provider_user_id). This lets
+// callers translate a TOCTOU race between a FindByProvider pre-check and a
+// concurrent insert into the appropriate domain-level error (e.g.
+// ErrEmailAlreadyTaken) without depending on driver-specific error shapes.
+var ErrDuplicateCredential = errors.New("repositories: duplicate credential (provider, provider_user_id)")
 
 // PaginatedResponse represents a paginated response with cursor-based pagination.
 type PaginatedResponse[T any] struct {

--- a/pkg/auth/infrastructure/database/gorm/migrate.go
+++ b/pkg/auth/infrastructure/database/gorm/migrate.go
@@ -10,6 +10,7 @@ func AutoMigrate(db *gorm.DB) error {
 	return db.AutoMigrate(
 		&models.AgentModel{},
 		&models.CredentialModel{},
+		&models.PasswordCredentialModel{},
 		&models.AuthSessionModel{},
 		&models.AccountModel{},
 		&models.AccountMemberModel{},

--- a/pkg/auth/infrastructure/database/gorm/password_credential_repository.go
+++ b/pkg/auth/infrastructure/database/gorm/password_credential_repository.go
@@ -1,0 +1,54 @@
+package gorm
+
+import (
+	"context"
+	"errors"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/models"
+	"gorm.io/gorm"
+)
+
+// passwordCredentialRepository implements repositories.PasswordCredentialRepository
+// using GORM.
+type passwordCredentialRepository struct {
+	db *gorm.DB
+}
+
+// NewPasswordCredentialRepository creates a new GORM-backed
+// PasswordCredentialRepository.
+func NewPasswordCredentialRepository(db *gorm.DB) repositories.PasswordCredentialRepository {
+	return &passwordCredentialRepository{db: db}
+}
+
+func (r *passwordCredentialRepository) Save(ctx context.Context, pc *entities.PasswordCredential) error {
+	m := models.PasswordCredentialModelFromEntity(pc)
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+func (r *passwordCredentialRepository) FindByID(ctx context.Context, id string) (*entities.PasswordCredential, error) {
+	var m models.PasswordCredentialModel
+	if err := r.db.WithContext(ctx).Where("id = ?", id).First(&m).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return m.ToEntity()
+}
+
+func (r *passwordCredentialRepository) FindByCredentialID(ctx context.Context, credentialID string) (*entities.PasswordCredential, error) {
+	var m models.PasswordCredentialModel
+	if err := r.db.WithContext(ctx).Where("credential_id = ?", credentialID).First(&m).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return m.ToEntity()
+}
+
+func (r *passwordCredentialRepository) Delete(ctx context.Context, credentialID string) error {
+	return r.db.WithContext(ctx).Where("credential_id = ?", credentialID).Delete(&models.PasswordCredentialModel{}).Error
+}

--- a/pkg/auth/infrastructure/database/gorm/password_credential_repository_test.go
+++ b/pkg/auth/infrastructure/database/gorm/password_credential_repository_test.go
@@ -1,0 +1,146 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	gorminfra "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/database/gorm"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+func TestPasswordCredentialRepository_SaveAndFind(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	repo := gorminfra.NewPasswordCredentialRepository(db)
+	ctx := context.Background()
+
+	pc, err := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err != nil {
+		t.Fatalf("create entity: %v", err)
+	}
+	if err := repo.Save(ctx, pc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	found, err := repo.FindByID(ctx, "pc-1")
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected to find by id, got nil")
+	}
+	if found.CredentialID() != "cred-1" {
+		t.Errorf("CredentialID() = %q, want cred-1", found.CredentialID())
+	}
+	if found.Hash() != "$2a$10$abc" {
+		t.Errorf("Hash() = %q, want $2a$10$abc", found.Hash())
+	}
+
+	byCred, err := repo.FindByCredentialID(ctx, "cred-1")
+	if err != nil {
+		t.Fatalf("FindByCredentialID: %v", err)
+	}
+	if byCred == nil {
+		t.Fatal("expected to find by credential_id, got nil")
+	}
+	if byCred.GetID() != "pc-1" {
+		t.Errorf("GetID() = %q, want pc-1", byCred.GetID())
+	}
+}
+
+func TestPasswordCredentialRepository_NotFoundReturnsNilNil(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	repo := gorminfra.NewPasswordCredentialRepository(db)
+	ctx := context.Background()
+
+	got, err := repo.FindByID(ctx, "missing")
+	if err != nil {
+		t.Fatalf("FindByID error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing id, got %+v", got)
+	}
+
+	got, err = repo.FindByCredentialID(ctx, "missing")
+	if err != nil {
+		t.Fatalf("FindByCredentialID error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing credential id, got %+v", got)
+	}
+}
+
+func TestPasswordCredentialRepository_UpdateOverwrites(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	repo := gorminfra.NewPasswordCredentialRepository(db)
+	ctx := context.Background()
+
+	pc, _ := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err := repo.Save(ctx, pc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := pc.Update("bcrypt", "$2a$12$new"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := repo.Save(ctx, pc); err != nil {
+		t.Fatalf("Save (update): %v", err)
+	}
+
+	found, err := repo.FindByCredentialID(ctx, "cred-1")
+	if err != nil {
+		t.Fatalf("FindByCredentialID: %v", err)
+	}
+	if found.Hash() != "$2a$12$new" {
+		t.Errorf("Hash() = %q, want $2a$12$new", found.Hash())
+	}
+}
+
+func TestPasswordCredentialRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	repo := gorminfra.NewPasswordCredentialRepository(db)
+	ctx := context.Background()
+
+	pc, _ := new(entities.PasswordCredential).With("pc-1", "cred-1", "bcrypt", "$2a$10$abc")
+	if err := repo.Save(ctx, pc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := repo.Delete(ctx, "cred-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, err := repo.FindByCredentialID(ctx, "cred-1")
+	if err != nil {
+		t.Fatalf("FindByCredentialID after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil after delete, got %+v", got)
+	}
+
+	// Idempotent: deleting again should not error.
+	if err := repo.Delete(ctx, "cred-1"); err != nil {
+		t.Fatalf("Delete (idempotent): %v", err)
+	}
+}

--- a/pkg/auth/infrastructure/database/gorm/repositories.go
+++ b/pkg/auth/infrastructure/database/gorm/repositories.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
@@ -10,6 +11,28 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/models"
 	"gorm.io/gorm"
 )
+
+// isDuplicateKeyError reports whether err describes a unique-constraint
+// violation. It first checks gorm.ErrDuplicatedKey (set when the connection
+// has TranslateError enabled) and falls back to driver-specific substrings
+// otherwise: SQLite ("UNIQUE constraint failed"), Postgres ("duplicate key
+// value violates unique constraint"), and MySQL ("Duplicate entry").
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "UNIQUE constraint failed"),
+		strings.Contains(msg, "duplicate key value violates unique constraint"),
+		strings.Contains(msg, "Duplicate entry"):
+		return true
+	}
+	return false
+}
 
 // agentRepository implements repositories.AgentRepository using GORM.
 type agentRepository struct {
@@ -212,7 +235,13 @@ func NewCredentialRepository(db *gorm.DB) repositories.CredentialRepository {
 
 func (r *credentialRepository) Save(ctx context.Context, credential *entities.Credential) error {
 	m := models.CredentialModelFromEntity(credential)
-	return r.db.WithContext(ctx).Save(m).Error
+	if err := r.db.WithContext(ctx).Save(m).Error; err != nil {
+		if isDuplicateKeyError(err) {
+			return repositories.ErrDuplicateCredential
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *credentialRepository) FindByID(ctx context.Context, id string) (*entities.Credential, error) {

--- a/pkg/auth/infrastructure/http/handlers_test.go
+++ b/pkg/auth/infrastructure/http/handlers_test.go
@@ -130,6 +130,22 @@ func (m *mockAuthService) IssueIdentityToken(ctx context.Context, agent *entitie
 	return "", nil
 }
 
+func (m *mockAuthService) RegisterPassword(_ context.Context, _, _, _ string) (*entities.Agent, *entities.Credential, *entities.Account, error) {
+	return nil, nil, nil, nil
+}
+
+func (m *mockAuthService) VerifyPassword(_ context.Context, _, _ string) (*entities.Agent, *entities.Credential, *entities.Account, error) {
+	return nil, nil, nil, nil
+}
+
+func (m *mockAuthService) ImportPasswordCredential(_ context.Context, _, _, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockAuthService) UpdatePassword(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 // --- Mock CredentialRepository ---
 
 type mockCredRepo struct {

--- a/pkg/auth/infrastructure/models/password_credential.go
+++ b/pkg/auth/infrastructure/models/password_credential.go
@@ -11,13 +11,18 @@ import (
 // aggregate. It is linked 1:1 to a Credential row of provider="password" by
 // CredentialID; the bcrypt hash is stored only here, never on the
 // CredentialModel.
+//
+// The "updated_at" column carries the domain meaning of "password rotated at"
+// (see PasswordCredential.UpdatedAt). The struct field is intentionally named
+// RotatedAt, not UpdatedAt, so GORM's auto-update timestamp magic does not
+// touch it on Saves that only change LastVerifiedAt (i.e. successful logins).
 type PasswordCredentialModel struct {
 	ID             string `gorm:"primaryKey"`
 	CredentialID   string `gorm:"not null;uniqueIndex:idx_password_credential_id"`
 	Algorithm      string `gorm:"not null"`
 	Hash           string `gorm:"not null"`
 	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	RotatedAt      time.Time `gorm:"column:updated_at"`
 	LastVerifiedAt time.Time
 }
 
@@ -28,8 +33,8 @@ func (PasswordCredentialModel) TableName() string {
 // String redacts the Hash field so the model is safe to log via %v / %+v.
 func (m PasswordCredentialModel) String() string {
 	return fmt.Sprintf(
-		"PasswordCredentialModel{ID:%s CredentialID:%s Algorithm:%s Hash:[REDACTED] CreatedAt:%s UpdatedAt:%s LastVerifiedAt:%s}",
-		m.ID, m.CredentialID, m.Algorithm, m.CreatedAt, m.UpdatedAt, m.LastVerifiedAt,
+		"PasswordCredentialModel{ID:%s CredentialID:%s Algorithm:%s Hash:[REDACTED] CreatedAt:%s RotatedAt:%s LastVerifiedAt:%s}",
+		m.ID, m.CredentialID, m.Algorithm, m.CreatedAt, m.RotatedAt, m.LastVerifiedAt,
 	)
 }
 
@@ -39,7 +44,7 @@ func (m PasswordCredentialModel) GoString() string { return m.String() }
 // ToEntity converts the GORM model to a PasswordCredential domain entity.
 func (m *PasswordCredentialModel) ToEntity() (*entities.PasswordCredential, error) {
 	e := &entities.PasswordCredential{}
-	if err := e.Restore(m.ID, m.CredentialID, m.Algorithm, m.Hash, m.CreatedAt, m.UpdatedAt, m.LastVerifiedAt); err != nil {
+	if err := e.Restore(m.ID, m.CredentialID, m.Algorithm, m.Hash, m.CreatedAt, m.RotatedAt, m.LastVerifiedAt); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -54,7 +59,7 @@ func PasswordCredentialModelFromEntity(e *entities.PasswordCredential) *Password
 		Algorithm:      e.Algorithm(),
 		Hash:           e.Hash(),
 		CreatedAt:      e.CreatedAt(),
-		UpdatedAt:      e.UpdatedAt(),
+		RotatedAt:      e.UpdatedAt(),
 		LastVerifiedAt: e.LastVerifiedAt(),
 	}
 }

--- a/pkg/auth/infrastructure/models/password_credential.go
+++ b/pkg/auth/infrastructure/models/password_credential.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
@@ -23,6 +24,17 @@ type PasswordCredentialModel struct {
 func (PasswordCredentialModel) TableName() string {
 	return "password_credentials"
 }
+
+// String redacts the Hash field so the model is safe to log via %v / %+v.
+func (m PasswordCredentialModel) String() string {
+	return fmt.Sprintf(
+		"PasswordCredentialModel{ID:%s CredentialID:%s Algorithm:%s Hash:[REDACTED] CreatedAt:%s UpdatedAt:%s LastVerifiedAt:%s}",
+		m.ID, m.CredentialID, m.Algorithm, m.CreatedAt, m.UpdatedAt, m.LastVerifiedAt,
+	)
+}
+
+// GoString mirrors String so that %#v also redacts the hash.
+func (m PasswordCredentialModel) GoString() string { return m.String() }
 
 // ToEntity converts the GORM model to a PasswordCredential domain entity.
 func (m *PasswordCredentialModel) ToEntity() (*entities.PasswordCredential, error) {

--- a/pkg/auth/infrastructure/models/password_credential.go
+++ b/pkg/auth/infrastructure/models/password_credential.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+)
+
+// PasswordCredentialModel is the GORM model for the PasswordCredential
+// aggregate. It is linked 1:1 to a Credential row of provider="password" by
+// CredentialID; the bcrypt hash is stored only here, never on the
+// CredentialModel.
+type PasswordCredentialModel struct {
+	ID             string `gorm:"primaryKey"`
+	CredentialID   string `gorm:"not null;uniqueIndex:idx_password_credential_id"`
+	Algorithm      string `gorm:"not null"`
+	Hash           string `gorm:"not null"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	LastVerifiedAt time.Time
+}
+
+func (PasswordCredentialModel) TableName() string {
+	return "password_credentials"
+}
+
+// ToEntity converts the GORM model to a PasswordCredential domain entity.
+func (m *PasswordCredentialModel) ToEntity() (*entities.PasswordCredential, error) {
+	e := &entities.PasswordCredential{}
+	if err := e.Restore(m.ID, m.CredentialID, m.Algorithm, m.Hash, m.CreatedAt, m.UpdatedAt, m.LastVerifiedAt); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// PasswordCredentialModelFromEntity converts a PasswordCredential domain
+// entity to a GORM model.
+func PasswordCredentialModelFromEntity(e *entities.PasswordCredential) *PasswordCredentialModel {
+	return &PasswordCredentialModel{
+		ID:             e.GetID(),
+		CredentialID:   e.CredentialID(),
+		Algorithm:      e.Algorithm(),
+		Hash:           e.Hash(),
+		CreatedAt:      e.CreatedAt(),
+		UpdatedAt:      e.UpdatedAt(),
+		LastVerifiedAt: e.LastVerifiedAt(),
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `PasswordCredential` as a separate aggregate (own KSUID, 1:1 with a `Credential` of `provider="password"`). Bcrypt hash lives only on the new `password_credentials` table — never on `Credential` and never in any event payload.
- Extends `AuthenticationService` with `RegisterPassword`, `VerifyPassword`, `ImportPasswordCredential`, `UpdatePassword`. Anti-enumeration: wrong-password and unknown-email both surface `ErrInvalidPassword`, with a dummy-hash compare to keep timing roughly constant.
- Bcrypt only (default cost configurable via `WithBcryptCost`). Algorithm stored on the row so future migration to argon2id is possible without rehashing.
- OAuth flow untouched. Password support is opt-in via `WithPasswordCredentialRepository`; password methods return `ErrPasswordSupportNotConfigured` until wired.
- Bcrypt blobs from legacy systems can be imported as-is via `ImportPasswordCredential` (idempotent on `(provider="password", lower(email))`).

Closes #12.

## Test plan

- [x] `go test -race ./...` (full suite passes including new in-memory SQLite integration tests)
- [x] `make lint` (0 issues)
- [x] Entity unit tests for `PasswordCredential` (With, Update, MarkVerified, Restore, ApplyEvent replay)
- [x] GORM repository tests (Save, FindByID, FindByCredentialID, Delete, idempotent delete, update overwrite)
- [x] Integration tests against in-memory SQLite covering register, verify (success / wrong-password / unknown-email / deactivated credential), update, import (success + idempotent + unknown agent), JWT issuance after register/verify, regression test for the timing-shield dummy bcrypt hash, regression test for `UpdatePassword` with event store wired (catches the rehydrated-aggregate UoW pitfall).
- [x] Anti-enumeration: `VerifyPassword` returns the same sentinel for wrong-password and unknown-email and exercises the dummy bcrypt path.
- [x] No plaintext or hash on any event payload (`PasswordCredentialCreated` and `PasswordUpdated` carry only metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)