### PR TITLE
feat(auth): SubscriptionService extensibility (closes #24)

### DIFF
--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -41,6 +41,17 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 
 ---
 
+### 2026-04-25: SubscriptionService adapters — RevenueCat / Stripe / GORM (Stories 2-4 of #24)
+
+- `pkg/auth/infrastructure/subscription/` ships three adapters implementing `application.SubscriptionService`. Each returns `(nil, nil)` for the canonical "no record" answer and an error only for transport / decode / config failures
+- **RevenueCat** (`revenuecat.go`): `GET /v1/subscribers/{agent_id}`, latest-expiring entitlement wins, lifetime entitlements (null `expires_date`) supersede time-bounded. Status switch consults the matched subscription row first then falls back to scanning all rows so multi-SKU offerings / upgrades / promo grants don't silently default to Active. Honors `unsubscribe_detected_at` so refunded lifetimes flip to Inactive
+- **Stripe** (`stripe.go`): `customers/search?query=metadata['agent_id']:'...'&expand[]=data.subscriptions`. Selection ranks active/trialing > past_due > canceled. The non-obvious case: Stripe transitions to `canceled` immediately when the merchant cancels even with `current_period_end` in the future and the customer still entitled — adapter keeps that as Active with `cancel_at_period_end=true` in Metadata until the period actually lapses, mirroring the existing treatment of cancel_at_period_end on still-active subscriptions. Stamps `customer_id` and `customer_match_count` to make split-brain billing setups (multiple customers per agent) detectable
+- **GORM** (`gorm.go`): default schema `SubscriptionRecord`. **Strict account scoping** is the load-bearing decision: when a non-empty accountID is requested, no agent-only fallback runs — the original implementation had a fallback that would silently return a paid personal-account subscription to a B2B/team token (caught by /pr-review's silent-failure-hunter). Returned claim's Status is validated via `SubscriptionStatus.Valid()` so a typo'd row or buggy resolver lands as an error, not a JWT claim
+- All three adapters take a configurable HTTP/DB seam plus relevant nil-safe option wrappers; tests use `httptest.Server` (REST) or in-memory SQLite via `glebarez/sqlite` (GORM)
+- **Why:** Closes the implementation half of issue #24 — the SubscriptionService interface from Story 1 needs concrete backends to be useful. Apollo's existing `infrastructure.Subscription` projection is a drop-in target for the GORM adapter; finexity and future MCP tiers can pick whichever fits their billing stack
+
+---
+
 ### 2026-04-25: SubscriptionClaim.IsActive honors ExpiresAt (PR #25 review)
 
 - `IsActive()` now returns false when `ExpiresAt` is non-zero and in the past, regardless of `Status`. Previously the field was carried through the JWT and into `ReissueToken` snapshots but never consulted, so a stale claim held across an account-switch could grant paid access past the provider-attested expiry. Zero `ExpiresAt` is still treated as "no expiry expressed" so providers without a fixed expiry (lifetime entitlements) keep working

--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -41,6 +41,15 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 
 ---
 
+### 2026-04-25: SubscriptionClaim.IsActive honors ExpiresAt (PR #25 review)
+
+- `IsActive()` now returns false when `ExpiresAt` is non-zero and in the past, regardless of `Status`. Previously the field was carried through the JWT and into `ReissueToken` snapshots but never consulted, so a stale claim held across an account-switch could grant paid access past the provider-attested expiry. Zero `ExpiresAt` is still treated as "no expiry expressed" so providers without a fixed expiry (lifetime entitlements) keep working
+- Added `SubscriptionStatus.Valid()` so adapter-side tests can assert the provider's status string normalization didn't drift (e.g., catching `"ACTIVE"` vs `"active"` before it silently downgrades a paying customer)
+- Tightened doc-strings flagged by review: `SubscriptionService` resolved the contradictory "should return non-nil Inactive" / "nil is also valid" prose into a single canonical contract; `ReissueToken` no longer overstates its claim-stability invariant; `RequireAuth` documents the session-vs-JWT divergence at the wiring point so a service mounting both middlewares isn't surprised by inconsistent `IsActive()` results
+- **Why:** Surfaced by silent-failure-hunter PR review on #25 — the `ExpiresAt` field existed end-to-end but no code path read it, which is exactly the kind of trap the review process is meant to catch
+
+---
+
 ### 2026-04-25: SubscriptionService extensibility — interface + JWT wiring (Story 1 of #24)
 
 - Added `auth.SubscriptionClaim` value type (`pkg/auth/subscription.go`) with `SubscriptionStatus` constants (`active`, `trialing`, `past_due`, `cancelled`, `inactive`) and an `IsActive()` helper that centralizes the "what counts as paying" rule (only `active` and `trialing` grant access)

--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -41,6 +41,19 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 
 ---
 
+### 2026-04-25: SubscriptionService extensibility — interface + JWT wiring (Story 1 of #24)
+
+- Added `auth.SubscriptionClaim` value type (`pkg/auth/subscription.go`) with `SubscriptionStatus` constants (`active`, `trialing`, `past_due`, `cancelled`, `inactive`) and an `IsActive()` helper that centralizes the "what counts as paying" rule (only `active` and `trialing` grant access)
+- Type lives in `pkg/auth` (not `pkg/auth/application`) so both `Identity` (in `pkg/auth`) and `PericarpClaims` (in `pkg/auth/application`) can reference it without an inverse import — `application` already depends on the parent package, but `auth` does not depend on `application`
+- Added `application.SubscriptionService` interface with `GetSubscription(ctx, agentID, accountID) (*auth.SubscriptionClaim, error)`
+- `JWTService.IssueToken` gained a 5th `subscription *auth.SubscriptionClaim` parameter (breaking change to internal API; ~13 test callsites updated mechanically). `ReissueToken` preserves the existing claim verbatim — account-switch reissuance does not re-query the SubscriptionService, so the snapshot is stable for the lifetime of the original sign-in
+- `AuthenticationService.IssueIdentityToken` orchestrates the lookup when a `SubscriptionService` is wired via `WithSubscriptionService(svc)`. Lookup failures are logged but do **not** block token issuance — billing-provider outages must not break login
+- `RequireJWT` middleware now copies `claims.Subscription` onto `auth.Identity.Subscription`, so consumer services read it via `auth.AgentFromCtx(ctx).Subscription`. Session-based `RequireAuth` leaves it nil (sessions don't snapshot subscription state)
+- **Why:** Apollo and other downstream services were hand-rolling subscription lookups on every protected request. Promoting subscription to a first-class JWT claim moves the lookup off the hot path (looked up once at issuance, lives for token TTL) and gives every consumer a single canonical type to read
+- **Open follow-ups (Stories 2-4):** RevenueCat, Stripe, and GORM adapter implementations under `pkg/auth/infrastructure/subscription/`
+
+---
+
 ### 2026-04-25: Password credential support in pkg/auth
 
 - Added `PasswordCredential` aggregate (`pkg/auth/domain/entities/password_credential.go`) — its own KSUID, linked 1:1 to a `Credential` row of `provider="password"` by `CredentialID`. Bcrypt hash stored only on this row, never on `Credential` and never in any event payload

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -528,8 +528,12 @@ func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, a
 		sub, err := s.subscriptionService.GetSubscription(ctx, agent.GetID(), activeAccountID)
 		if err != nil {
 			s.logger.Warn(ctx, "auth: subscription lookup failed", "agent_id", agent.GetID(), "active_account_id", activeAccountID, "error", err)
-		} else {
-			subscription = sub
+		} else if sub != nil {
+			if sub.Status.Valid() {
+				subscription = sub
+			} else {
+				s.logger.Warn(ctx, "auth: subscription lookup returned invalid status", "agent_id", agent.GetID(), "active_account_id", activeAccountID, "status", sub.Status)
+			}
 		}
 	}
 	return s.jwtService.IssueToken(ctx, agent, accounts, activeAccountID, subscription)

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	"github.com/akeemphilbert/pericarp/pkg/ddd"
@@ -20,17 +21,17 @@ import (
 
 // Sentinel errors for the authentication domain.
 var (
-	ErrInvalidProvider               = errors.New("authentication: invalid provider")
-	ErrInvalidState                  = errors.New("authentication: invalid state parameter")
-	ErrCodeExchangeFailed            = errors.New("authentication: code exchange failed")
-	ErrSessionNotFound               = errors.New("authentication: session not found")
-	ErrSessionExpired                = errors.New("authentication: session expired")
-	ErrSessionRevoked                = errors.New("authentication: session revoked")
-	ErrTokenRefreshFailed            = errors.New("authentication: token refresh failed")
-	ErrCredentialNotFound            = errors.New("authentication: credential not found")
-	ErrEmailAlreadyTaken             = errors.New("authentication: email already registered with a password")
-	ErrPasswordSupportNotConfigured  = errors.New("authentication: password support not configured")
-	ErrPasswordCredentialMissing     = errors.New("authentication: password credential not found for agent")
+	ErrInvalidProvider              = errors.New("authentication: invalid provider")
+	ErrInvalidState                 = errors.New("authentication: invalid state parameter")
+	ErrCodeExchangeFailed           = errors.New("authentication: code exchange failed")
+	ErrSessionNotFound              = errors.New("authentication: session not found")
+	ErrSessionExpired               = errors.New("authentication: session expired")
+	ErrSessionRevoked               = errors.New("authentication: session revoked")
+	ErrTokenRefreshFailed           = errors.New("authentication: token refresh failed")
+	ErrCredentialNotFound           = errors.New("authentication: credential not found")
+	ErrEmailAlreadyTaken            = errors.New("authentication: email already registered with a password")
+	ErrPasswordSupportNotConfigured = errors.New("authentication: password support not configured")
+	ErrPasswordCredentialMissing    = errors.New("authentication: password credential not found for agent")
 )
 
 // AuthRequest represents the result of initiating an OAuth authorization flow.
@@ -179,6 +180,7 @@ type DefaultAuthenticationService struct {
 	authorization       AuthorizationChecker
 	logger              Logger
 	jwtService          JWTService
+	subscriptionService SubscriptionService
 	bcryptCost          int
 	dummyHashOnce       sync.Once
 	dummyHashValue      string
@@ -503,6 +505,12 @@ func (s *DefaultAuthenticationService) RevokeAllSessions(ctx context.Context, ag
 
 // IssueIdentityToken issues a signed JWT for the given agent.
 // Returns ("", nil) if no JWTService is configured.
+//
+// When a SubscriptionService is configured, this method snapshots the agent's
+// current subscription state and embeds it as a claim. Subscription lookup
+// failures are logged but do not block token issuance — billing-provider
+// outages must not break login. The consumer interprets a missing claim as
+// "no active subscription".
 func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error) {
 	if s.jwtService == nil {
 		return "", nil
@@ -518,7 +526,16 @@ func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, a
 			return "", fmt.Errorf("authentication: failed to fetch accounts for token: %w", err)
 		}
 	}
-	return s.jwtService.IssueToken(ctx, agent, accounts, activeAccountID)
+	var subscription *auth.SubscriptionClaim
+	if s.subscriptionService != nil {
+		sub, err := s.subscriptionService.GetSubscription(ctx, agent.GetID(), activeAccountID)
+		if err != nil {
+			s.logger.Warn(ctx, "auth: subscription lookup failed", "agent_id", agent.GetID(), "active_account_id", activeAccountID, "error", err)
+		} else {
+			subscription = sub
+		}
+	}
+	return s.jwtService.IssueToken(ctx, agent, accounts, activeAccountID, subscription)
 }
 
 // normalizeEmail returns the canonical form of an email used as the

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -503,14 +503,11 @@ func (s *DefaultAuthenticationService) RevokeAllSessions(ctx context.Context, ag
 	return s.sessions.RevokeAllForAgent(ctx, agentID)
 }
 
-// IssueIdentityToken issues a signed JWT for the given agent.
-// Returns ("", nil) if no JWTService is configured.
-//
-// When a SubscriptionService is configured, this method snapshots the agent's
-// current subscription state and embeds it as a claim. Subscription lookup
-// failures are logged but do not block token issuance — billing-provider
-// outages must not break login. The consumer interprets a missing claim as
-// "no active subscription".
+// IssueIdentityToken issues a signed JWT for the given agent, or ("", nil)
+// if no JWTService is configured. When a SubscriptionService is wired the
+// current claim is snapshotted into the token; lookup failures are logged
+// but do not block issuance — billing-provider outages must not break
+// login.
 func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error) {
 	if s.jwtService == nil {
 		return "", nil

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
@@ -899,12 +900,16 @@ func TestDefaultAuthenticationService_RefreshTokens_ProviderFails(t *testing.T) 
 // --- Mock JWTService ---
 
 type mockJWTService struct {
-	issueFunc func(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string) (string, error)
+	issueFunc func(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string, subscription *auth.SubscriptionClaim) (string, error)
+	// lastSubscription captures the subscription passed to IssueToken so
+	// SubscriptionService-driven tests can assert what was embedded.
+	lastSubscription *auth.SubscriptionClaim
 }
 
-func (m *mockJWTService) IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string) (string, error) {
+func (m *mockJWTService) IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string, subscription *auth.SubscriptionClaim) (string, error) {
+	m.lastSubscription = subscription
 	if m.issueFunc != nil {
-		return m.issueFunc(ctx, agent, accounts, activeAccountID)
+		return m.issueFunc(ctx, agent, accounts, activeAccountID, subscription)
 	}
 	return "mock-jwt-token", nil
 }
@@ -1027,6 +1032,132 @@ func TestIssueIdentityToken_NilAccountRepo_StillIssuesToken(t *testing.T) {
 	}
 	if token != "mock-jwt-token" {
 		t.Errorf("expected %q, got %q", "mock-jwt-token", token)
+	}
+}
+
+// --- SubscriptionService wiring tests ---
+
+type mockSubscriptionService struct {
+	claim         *auth.SubscriptionClaim
+	err           error
+	calledAgentID string
+	calledAccount string
+	called        bool
+}
+
+func (m *mockSubscriptionService) GetSubscription(_ context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+	m.called = true
+	m.calledAgentID = agentID
+	m.calledAccount = accountID
+	return m.claim, m.err
+}
+
+func TestIssueIdentityToken_NoSubscriptionService_OmitsClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	jwtSvc := &mockJWTService{}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+	)
+
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "account-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() error: %v", err)
+	}
+	if jwtSvc.lastSubscription != nil {
+		t.Errorf("expected nil subscription, got %+v", jwtSvc.lastSubscription)
+	}
+}
+
+func TestIssueIdentityToken_WithSubscriptionService_EmbedsClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	want := &auth.SubscriptionClaim{
+		Status:   auth.SubscriptionStatusActive,
+		Plan:     "pro",
+		Provider: "stripe",
+	}
+	subSvc := &mockSubscriptionService{claim: want}
+	jwtSvc := &mockJWTService{}
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+		application.WithSubscriptionService(subSvc),
+	)
+
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "account-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() error: %v", err)
+	}
+	if !subSvc.called {
+		t.Fatal("SubscriptionService.GetSubscription was not called")
+	}
+	if subSvc.calledAgentID != "agent-1" {
+		t.Errorf("called agentID = %q, want %q", subSvc.calledAgentID, "agent-1")
+	}
+	if subSvc.calledAccount != "account-1" {
+		t.Errorf("called accountID = %q, want %q", subSvc.calledAccount, "account-1")
+	}
+	if jwtSvc.lastSubscription != want {
+		t.Errorf("subscription passed to JWTService = %+v, want %+v", jwtSvc.lastSubscription, want)
+	}
+}
+
+func TestIssueIdentityToken_SubscriptionLookupError_TokenStillIssued(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	subSvc := &mockSubscriptionService{err: errors.New("billing provider unreachable")}
+	jwtSvc := &mockJWTService{}
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+		application.WithSubscriptionService(subSvc),
+	)
+
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	token, err := svc.IssueIdentityToken(ctx, agent, "account-1")
+	if err != nil {
+		t.Fatalf("IssueIdentityToken() error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected token despite subscription lookup error, got empty")
+	}
+	if jwtSvc.lastSubscription != nil {
+		t.Errorf("expected nil subscription on lookup error, got %+v", jwtSvc.lastSubscription)
+	}
+}
+
+func TestWithSubscriptionService_NilNoOp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	jwtSvc := &mockJWTService{}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+		application.WithSubscriptionService(nil),
+	)
+
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "account-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() error: %v", err)
+	}
+	if jwtSvc.lastSubscription != nil {
+		t.Errorf("expected nil subscription, got %+v", jwtSvc.lastSubscription)
 	}
 }
 

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -1111,6 +1111,37 @@ func TestIssueIdentityToken_WithSubscriptionService_EmbedsClaim(t *testing.T) {
 	}
 }
 
+func TestIssueIdentityToken_NonNilInactiveClaim_EmbeddedAsIs(t *testing.T) {
+	// Adapters that distinguish "no record" from "found, no paid plan"
+	// return a non-nil claim with Status=Inactive. Verify that flows
+	// through end-to-end rather than getting collapsed into nil.
+	t.Parallel()
+	ctx := context.Background()
+
+	want := &auth.SubscriptionClaim{Status: auth.SubscriptionStatusInactive, Provider: "stripe"}
+	subSvc := &mockSubscriptionService{claim: want}
+	jwtSvc := &mockJWTService{}
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+		application.WithSubscriptionService(subSvc),
+	)
+
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "account-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() error: %v", err)
+	}
+	if jwtSvc.lastSubscription != want {
+		t.Fatalf("subscription passed to JWTService = %+v, want %+v", jwtSvc.lastSubscription, want)
+	}
+	if jwtSvc.lastSubscription.IsActive() {
+		t.Error("inactive claim should not report active")
+	}
+}
+
 func TestIssueIdentityToken_SubscriptionLookupError_TokenStillIssued(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/auth/application/jwt_service.go
+++ b/pkg/auth/application/jwt_service.go
@@ -19,11 +19,10 @@ var (
 
 // PericarpClaims contains the JWT claims issued by the auth system.
 // AgentID mirrors RegisteredClaims.Subject for convenient access without
-// parsing the standard "sub" field.
-//
-// Subscription is set by AuthenticationService.IssueIdentityToken when a
-// SubscriptionService is configured; it is omitted from the JWT when nil so
-// tokens issued in opaque-session-only deployments stay byte-compatible.
+// parsing the standard "sub" field. Subscription is set by
+// AuthenticationService.IssueIdentityToken when a SubscriptionService is
+// configured; the omitempty tag keeps the claim absent (rather than null)
+// in opaque-session-only deployments.
 type PericarpClaims struct {
 	jwt.RegisteredClaims
 	AgentID         string                  `json:"agent_id"`

--- a/pkg/auth/application/jwt_service.go
+++ b/pkg/auth/application/jwt_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -19,17 +20,24 @@ var (
 // PericarpClaims contains the JWT claims issued by the auth system.
 // AgentID mirrors RegisteredClaims.Subject for convenient access without
 // parsing the standard "sub" field.
+//
+// Subscription is set by AuthenticationService.IssueIdentityToken when a
+// SubscriptionService is configured; it is omitted from the JWT when nil so
+// tokens issued in opaque-session-only deployments stay byte-compatible.
 type PericarpClaims struct {
 	jwt.RegisteredClaims
-	AgentID         string   `json:"agent_id"`
-	AccountIDs      []string `json:"account_ids"`
-	ActiveAccountID string   `json:"active_account_id,omitempty"`
+	AgentID         string                  `json:"agent_id"`
+	AccountIDs      []string                `json:"account_ids"`
+	ActiveAccountID string                  `json:"active_account_id,omitempty"`
+	Subscription    *auth.SubscriptionClaim `json:"subscription,omitempty"`
 }
 
 // JWTService defines the interface for issuing and validating JWTs.
 type JWTService interface {
 	// IssueToken creates a signed JWT for the given agent and accounts.
-	IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string) (string, error)
+	// A non-nil subscription is embedded as the "subscription" claim;
+	// nil omits the claim.
+	IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string, subscription *auth.SubscriptionClaim) (string, error)
 
 	// ValidateToken parses and validates a JWT string, returning the claims.
 	ValidateToken(ctx context.Context, tokenString string) (*PericarpClaims, error)

--- a/pkg/auth/application/options.go
+++ b/pkg/auth/application/options.go
@@ -70,8 +70,8 @@ func WithPasswordCredentialRepository(repo repositories.PasswordCredentialReposi
 }
 
 // WithSubscriptionService wires a SubscriptionService for snapshotting
-// subscription state into issued JWTs. When unset, the issued tokens omit
-// the subscription claim and consumers see an inactive subscription.
+// subscription state into issued JWTs. When unset, IssueIdentityToken
+// issues tokens with no subscription claim.
 func WithSubscriptionService(svc SubscriptionService) AuthServiceOption {
 	return func(s *DefaultAuthenticationService) {
 		if svc != nil {

--- a/pkg/auth/application/options.go
+++ b/pkg/auth/application/options.go
@@ -69,6 +69,17 @@ func WithPasswordCredentialRepository(repo repositories.PasswordCredentialReposi
 	}
 }
 
+// WithSubscriptionService wires a SubscriptionService for snapshotting
+// subscription state into issued JWTs. When unset, the issued tokens omit
+// the subscription claim and consumers see an inactive subscription.
+func WithSubscriptionService(svc SubscriptionService) AuthServiceOption {
+	return func(s *DefaultAuthenticationService) {
+		if svc != nil {
+			s.subscriptionService = svc
+		}
+	}
+}
+
 // WithBcryptCost overrides the bcrypt cost used when hashing newly
 // registered or updated passwords. A non-positive value falls back to
 // bcrypt.DefaultCost.

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -445,7 +445,7 @@ func TestImportPasswordCredential_RejectsMalformedHash(t *testing.T) {
 
 	cases := []string{
 		"not-a-bcrypt-hash",
-		"$2a$10$abc",          // truncated
+		"$2a$10$abc",         // truncated
 		"plaintext-password", // obvious migration mistake
 	}
 	for _, badHash := range cases {

--- a/pkg/auth/application/subscription_service.go
+++ b/pkg/auth/application/subscription_service.go
@@ -1,0 +1,21 @@
+package application
+
+import (
+	"context"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+)
+
+// SubscriptionService resolves the current subscription state for an agent
+// at token-issuance time. The resulting SubscriptionClaim is embedded in the
+// JWT so consumer services can gate paid-tier access without per-request
+// billing API calls.
+//
+// Implementations should return a non-nil *SubscriptionClaim with
+// SubscriptionStatusInactive when the agent has no record at the provider,
+// so the absence of a paid plan is captured explicitly rather than as a
+// nil claim. A nil claim with a nil error means "no claim to embed" and is
+// also valid (the JWT will omit the field).
+type SubscriptionService interface {
+	GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error)
+}

--- a/pkg/auth/application/subscription_service.go
+++ b/pkg/auth/application/subscription_service.go
@@ -7,15 +7,13 @@ import (
 )
 
 // SubscriptionService resolves the current subscription state for an agent
-// at token-issuance time. The resulting SubscriptionClaim is embedded in the
-// JWT so consumer services can gate paid-tier access without per-request
-// billing API calls.
-//
-// Implementations should return a non-nil *SubscriptionClaim with
-// SubscriptionStatusInactive when the agent has no record at the provider,
-// so the absence of a paid plan is captured explicitly rather than as a
-// nil claim. A nil claim with a nil error means "no claim to embed" and is
-// also valid (the JWT will omit the field).
+// at token-issuance time. The resulting SubscriptionClaim is embedded in
+// the JWT so consumer services can gate paid-tier access without per-
+// request billing API calls. Returning (nil, nil) is the canonical "no
+// record" answer — the claim is omitted from the token and consumers see
+// inactive via SubscriptionClaim.IsActive on the nil pointer. Errors are
+// logged by the caller and treated the same as no record so a billing-
+// provider outage cannot block login.
 type SubscriptionService interface {
 	GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error)
 }

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -10,10 +10,15 @@ var identityKey = &contextKey{"pericarp-identity"}
 
 // Identity represents an authenticated agent's identity, independent of the
 // underlying authentication mechanism (JWT, session, etc.).
+//
+// Subscription is populated by JWT-validating middleware when the validated
+// token carries a subscription claim. Session-based authentication leaves
+// it nil — sessions don't snapshot subscription state.
 type Identity struct {
 	AgentID         string
 	AccountIDs      []string
 	ActiveAccountID string
+	Subscription    *SubscriptionClaim
 }
 
 // AgentFromCtx extracts the Identity from ctx. Returns nil if no identity is present.

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -9,11 +9,9 @@ type contextKey struct{ name string }
 var identityKey = &contextKey{"pericarp-identity"}
 
 // Identity represents an authenticated agent's identity, independent of the
-// underlying authentication mechanism (JWT, session, etc.).
-//
-// Subscription is populated by JWT-validating middleware when the validated
-// token carries a subscription claim. Session-based authentication leaves
-// it nil — sessions don't snapshot subscription state.
+// underlying authentication mechanism (JWT, session, etc.). Subscription
+// carries the snapshot from a JWT subscription claim when present; session-
+// only auth paths have nothing to snapshot and leave it nil.
 type Identity struct {
 	AgentID         string
 	AccountIDs      []string

--- a/pkg/auth/infrastructure/http/handlers_test.go
+++ b/pkg/auth/infrastructure/http/handlers_test.go
@@ -820,7 +820,7 @@ func TestCallback_WithJWT_SetsCookie(t *testing.T) {
 	svc := &mockAuthService{
 		issueIdentityTokenFunc: func(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error) {
 			account, _ := new(entities.Account).With("account-1", "Test Account", entities.AccountTypePersonal)
-			return jwtSvc.IssueToken(ctx, agent, []*entities.Account{account}, activeAccountID)
+			return jwtSvc.IssueToken(ctx, agent, []*entities.Account{account}, activeAccountID, nil)
 		},
 	}
 

--- a/pkg/auth/infrastructure/http/middleware.go
+++ b/pkg/auth/infrastructure/http/middleware.go
@@ -22,7 +22,12 @@ var (
 
 // RequireAuth returns HTTP middleware that validates the session cookie and
 // injects the SessionInfo into the request context.
-// It also injects an auth.Identity for use via auth.AgentFromCtx.
+// It also injects an auth.Identity for use via auth.AgentFromCtx. The
+// injected Identity.Subscription is always nil — sessions don't snapshot
+// subscription state. Services that mix RequireAuth and RequireJWT will
+// see different IsActive() results for the same agent depending on which
+// middleware served the request; gate paid-tier features behind RequireJWT
+// or fetch subscription state explicitly under RequireAuth.
 // Unauthenticated requests receive a 401 JSON response.
 func RequireAuth(
 	sm session.SessionManager,

--- a/pkg/auth/infrastructure/http/middleware.go
+++ b/pkg/auth/infrastructure/http/middleware.go
@@ -95,6 +95,7 @@ func RequireJWT(jwtService application.JWTService, cookieName string) func(http.
 				AgentID:         claims.AgentID,
 				AccountIDs:      claims.AccountIDs,
 				ActiveAccountID: claims.ActiveAccountID,
+				Subscription:    claims.Subscription,
 			}
 			ctx = auth.ContextWithAgent(ctx, id)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/auth/infrastructure/http/middleware_test.go
+++ b/pkg/auth/infrastructure/http/middleware_test.go
@@ -179,7 +179,7 @@ func issueTestToken(t *testing.T, svc *authjwt.RSAJWTService) string {
 	if err != nil {
 		t.Fatalf("failed to create account: %v", err)
 	}
-	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{account}, "acc-1")
+	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{account}, "acc-1", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -271,6 +271,57 @@ func TestRequireJWT_ValidBearerToken_InjectsClaimsAndCallsNext(t *testing.T) {
 	}
 	if capturedClaims.ActiveAccountID != "acc-1" {
 		t.Errorf("ActiveAccountID = %q, want %q", capturedClaims.ActiveAccountID, "acc-1")
+	}
+}
+
+func TestRequireJWT_PopulatesIdentitySubscription(t *testing.T) {
+	t.Parallel()
+
+	svc, _ := newTestJWTService(t)
+
+	agent, err := new(entities.Agent).With("agent-1", "Test User", entities.AgentTypePerson)
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	subscription := &auth.SubscriptionClaim{
+		Status:   auth.SubscriptionStatusActive,
+		Plan:     "pro",
+		Provider: "stripe",
+	}
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", subscription)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	var capturedIdentity *auth.Identity
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedIdentity = auth.AgentFromCtx(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := authhttp.RequireJWT(svc, "")
+	handler := middleware(next)
+
+	r := httptest.NewRequest("GET", "/protected", nil)
+	r.Header.Set("Authorization", "Bearer "+tokenString)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if capturedIdentity == nil {
+		t.Fatal("expected Identity in context, got nil")
+	}
+	if capturedIdentity.Subscription == nil {
+		t.Fatal("expected Subscription on Identity, got nil")
+	}
+	if capturedIdentity.Subscription.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q", capturedIdentity.Subscription.Status, auth.SubscriptionStatusActive)
+	}
+	if !capturedIdentity.Subscription.IsActive() {
+		t.Error("IsActive() = false, want true")
 	}
 }
 

--- a/pkg/auth/infrastructure/http/middleware_test.go
+++ b/pkg/auth/infrastructure/http/middleware_test.go
@@ -498,6 +498,9 @@ func TestRequireAuth_ValidSession_InjectsIdentity(t *testing.T) {
 	if len(capturedID.AccountIDs) != 1 || capturedID.AccountIDs[0] != "acc-1" {
 		t.Errorf("AccountIDs = %v, want [acc-1]", capturedID.AccountIDs)
 	}
+	if capturedID.Subscription != nil {
+		t.Errorf("Identity.Subscription = %+v, want nil — sessions don't carry subscription state", capturedID.Subscription)
+	}
 }
 
 func TestRequireJWT_NoToken_NoIdentity(t *testing.T) {

--- a/pkg/auth/infrastructure/http/switch_account_test.go
+++ b/pkg/auth/infrastructure/http/switch_account_test.go
@@ -56,7 +56,7 @@ func issueMultiAccountToken(t *testing.T, svc *authjwt.RSAJWTService, activeAcco
 	if err != nil {
 		t.Fatalf("failed to create account: %v", err)
 	}
-	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{acc1, acc2}, activeAccountID)
+	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{acc1, acc2}, activeAccountID, nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}

--- a/pkg/auth/infrastructure/jwt/rsa_jwt_service.go
+++ b/pkg/auth/infrastructure/jwt/rsa_jwt_service.go
@@ -173,9 +173,10 @@ func (s *RSAJWTService) ValidateInviteToken(ctx context.Context, tokenString str
 
 // ReissueToken creates a new JWT with a different ActiveAccountID, copying
 // AgentID, Subject, AccountIDs, and Subscription from the existing claims.
-// The subscription claim is preserved verbatim — account-switch reissuance
-// does not re-query the SubscriptionService, so the snapshot stays stable
-// for the lifetime of the original sign-in.
+// The subscription claim is copied verbatim — account-switch reissuance
+// prefers a stale-but-stable snapshot over a per-switch billing call. A
+// fresh snapshot is only taken on the next IssueIdentityToken (e.g. when
+// the JWT expires and the user re-authenticates).
 func (s *RSAJWTService) ReissueToken(ctx context.Context, claims *application.PericarpClaims, activeAccountID string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err

--- a/pkg/auth/infrastructure/jwt/rsa_jwt_service.go
+++ b/pkg/auth/infrastructure/jwt/rsa_jwt_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	gojwt "github.com/golang-jwt/jwt/v5"
@@ -38,7 +39,8 @@ func NewRSAJWTService(opts ...RSAJWTServiceOption) *RSAJWTService {
 }
 
 // IssueToken creates a signed JWT for the given agent and accounts.
-func (s *RSAJWTService) IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string) (string, error) {
+// A non-nil subscription is embedded as the "subscription" claim.
+func (s *RSAJWTService) IssueToken(ctx context.Context, agent *entities.Agent, accounts []*entities.Account, activeAccountID string, subscription *auth.SubscriptionClaim) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -66,6 +68,7 @@ func (s *RSAJWTService) IssueToken(ctx context.Context, agent *entities.Agent, a
 		AgentID:         agent.GetID(),
 		AccountIDs:      accountIDs,
 		ActiveAccountID: activeAccountID,
+		Subscription:    subscription,
 	}
 
 	token := gojwt.NewWithClaims(gojwt.SigningMethodRS256, claims)
@@ -169,7 +172,10 @@ func (s *RSAJWTService) ValidateInviteToken(ctx context.Context, tokenString str
 }
 
 // ReissueToken creates a new JWT with a different ActiveAccountID, copying
-// AgentID, Subject, and AccountIDs from the existing claims.
+// AgentID, Subject, AccountIDs, and Subscription from the existing claims.
+// The subscription claim is preserved verbatim — account-switch reissuance
+// does not re-query the SubscriptionService, so the snapshot stays stable
+// for the lifetime of the original sign-in.
 func (s *RSAJWTService) ReissueToken(ctx context.Context, claims *application.PericarpClaims, activeAccountID string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -193,6 +199,7 @@ func (s *RSAJWTService) ReissueToken(ctx context.Context, claims *application.Pe
 		AgentID:         claims.AgentID,
 		AccountIDs:      claims.AccountIDs,
 		ActiveAccountID: activeAccountID,
+		Subscription:    claims.Subscription,
 	}
 
 	token := gojwt.NewWithClaims(gojwt.SigningMethodRS256, newClaims)

--- a/pkg/auth/infrastructure/jwt/rsa_jwt_service_test.go
+++ b/pkg/auth/infrastructure/jwt/rsa_jwt_service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
@@ -52,7 +53,7 @@ func TestIssueAndValidate_RoundTrip(t *testing.T) {
 		createTestAccount(t, "acc-2", "Account Two"),
 	}
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1")
+	tokenString, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestIssueToken_NoSigningKey(t *testing.T) {
 	svc := authjwt.NewRSAJWTService() // no key
 	agent := createTestAgent(t, "agent-1", "Test User")
 
-	_, err := svc.IssueToken(context.Background(), agent, nil, "")
+	_, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != application.ErrNoSigningKey {
 		t.Errorf("expected ErrNoSigningKey, got %v", err)
 	}
@@ -110,7 +111,7 @@ func TestIssueToken_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := svc.IssueToken(ctx, agent, nil, "")
+	_, err := svc.IssueToken(ctx, agent, nil, "", nil)
 	if err != context.Canceled {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -126,7 +127,7 @@ func TestValidateToken_ExpiredToken(t *testing.T) {
 	)
 	agent := createTestAgent(t, "agent-1", "Test User")
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "")
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestValidateToken_WrongKey(t *testing.T) {
 	svcB := authjwt.NewRSAJWTService(authjwt.WithSigningKey(keyB))
 
 	agent := createTestAgent(t, "agent-1", "Test User")
-	tokenString, err := svcA.IssueToken(context.Background(), agent, nil, "")
+	tokenString, err := svcA.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -180,7 +181,7 @@ func TestIssueToken_EmptyAccounts(t *testing.T) {
 	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
 	agent := createTestAgent(t, "agent-1", "Test User")
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{}, "")
+	tokenString, err := svc.IssueToken(context.Background(), agent, []*entities.Account{}, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestIssueToken_MultipleAccounts(t *testing.T) {
 		createTestAccount(t, "acc-3", "Account Three"),
 	}
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, accounts, "acc-2")
+	tokenString, err := svc.IssueToken(context.Background(), agent, accounts, "acc-2", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -235,7 +236,7 @@ func TestSubjectEqualsAgentID(t *testing.T) {
 	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
 	agent := createTestAgent(t, "agent-42", "Test User")
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "")
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -260,7 +261,7 @@ func TestCustomTTLAndIssuer(t *testing.T) {
 	)
 	agent := createTestAgent(t, "agent-1", "Test User")
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "")
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -287,7 +288,7 @@ func TestValidateToken_CancelledContext(t *testing.T) {
 	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
 	agent := createTestAgent(t, "agent-1", "Test User")
 
-	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "")
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -318,9 +319,118 @@ func TestIssueToken_NilAgent(t *testing.T) {
 	key := generateTestKey(t)
 	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
 
-	_, err := svc.IssueToken(context.Background(), nil, nil, "")
+	_, err := svc.IssueToken(context.Background(), nil, nil, "", nil)
 	if err == nil {
 		t.Fatal("expected error for nil agent, got nil")
+	}
+}
+
+func TestIssueToken_SubscriptionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := generateTestKey(t)
+	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
+
+	agent := createTestAgent(t, "agent-1", "Test User")
+	expires := time.Now().Add(30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	subscription := &auth.SubscriptionClaim{
+		Status:    auth.SubscriptionStatusActive,
+		Plan:      "pro",
+		Provider:  "stripe",
+		ExpiresAt: expires,
+		Metadata:  map[string]any{"price_id": "price_123"},
+	}
+
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", subscription)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	claims, err := svc.ValidateToken(context.Background(), tokenString)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+	if claims.Subscription == nil {
+		t.Fatal("expected subscription claim, got nil")
+	}
+	if claims.Subscription.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q", claims.Subscription.Status, auth.SubscriptionStatusActive)
+	}
+	if claims.Subscription.Plan != "pro" {
+		t.Errorf("Plan = %q, want %q", claims.Subscription.Plan, "pro")
+	}
+	if claims.Subscription.Provider != "stripe" {
+		t.Errorf("Provider = %q, want %q", claims.Subscription.Provider, "stripe")
+	}
+	if !claims.Subscription.ExpiresAt.Equal(expires) {
+		t.Errorf("ExpiresAt = %v, want %v", claims.Subscription.ExpiresAt, expires)
+	}
+	if got := claims.Subscription.Metadata["price_id"]; got != "price_123" {
+		t.Errorf("Metadata[price_id] = %v, want %q", got, "price_123")
+	}
+	if !claims.Subscription.IsActive() {
+		t.Error("IsActive() = false, want true for active status")
+	}
+}
+
+func TestIssueToken_NoSubscription_OmitsClaim(t *testing.T) {
+	t.Parallel()
+
+	key := generateTestKey(t)
+	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
+
+	agent := createTestAgent(t, "agent-1", "Test User")
+
+	tokenString, err := svc.IssueToken(context.Background(), agent, nil, "", nil)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	claims, err := svc.ValidateToken(context.Background(), tokenString)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+	if claims.Subscription != nil {
+		t.Errorf("expected nil subscription, got %+v", claims.Subscription)
+	}
+}
+
+func TestReissueToken_PreservesSubscription(t *testing.T) {
+	t.Parallel()
+
+	key := generateTestKey(t)
+	svc := authjwt.NewRSAJWTService(authjwt.WithSigningKey(key))
+
+	agent := createTestAgent(t, "agent-1", "Test User")
+	subscription := &auth.SubscriptionClaim{Status: auth.SubscriptionStatusTrialing, Plan: "trial"}
+
+	originalToken, err := svc.IssueToken(context.Background(), agent, nil, "acc-1", subscription)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	originalClaims, err := svc.ValidateToken(context.Background(), originalToken)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+
+	reissuedToken, err := svc.ReissueToken(context.Background(), originalClaims, "acc-2")
+	if err != nil {
+		t.Fatalf("ReissueToken failed: %v", err)
+	}
+
+	newClaims, err := svc.ValidateToken(context.Background(), reissuedToken)
+	if err != nil {
+		t.Fatalf("ValidateToken on reissued token failed: %v", err)
+	}
+	if newClaims.Subscription == nil {
+		t.Fatal("reissued token should preserve subscription claim")
+	}
+	if newClaims.Subscription.Status != auth.SubscriptionStatusTrialing {
+		t.Errorf("Status = %q, want %q", newClaims.Subscription.Status, auth.SubscriptionStatusTrialing)
+	}
+	if newClaims.Subscription.Plan != "trial" {
+		t.Errorf("Plan = %q, want %q", newClaims.Subscription.Plan, "trial")
 	}
 }
 
@@ -432,7 +542,7 @@ func TestReissueToken_RoundTrip(t *testing.T) {
 		createTestAccount(t, "acc-2", "Account Two"),
 	}
 
-	originalToken, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1")
+	originalToken, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}
@@ -480,7 +590,7 @@ func TestReissueToken_FreshTimestamps(t *testing.T) {
 		createTestAccount(t, "acc-1", "Account One"),
 	}
 
-	originalToken, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1")
+	originalToken, err := svc.IssueToken(context.Background(), agent, accounts, "acc-1", nil)
 	if err != nil {
 		t.Fatalf("IssueToken failed: %v", err)
 	}

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -82,11 +82,15 @@ func WithGORMProvider(name string) GORMOption {
 // GORM resolves SubscriptionClaim values from a relational projection
 // owned by the consumer service. Implements application.SubscriptionService.
 //
-// The default resolver expects a table matching SubscriptionRecord and
-// picks, for the given (agentID, accountID), the row with the latest
-// updated_at — preferring an exact account match when accountID is
-// non-empty, falling back to the agent-only row otherwise. For schemas
-// that don't fit that shape, supply WithGORMResolver.
+// The default resolver expects a table matching SubscriptionRecord. When
+// accountID is non-empty the lookup requires an exact (agent_id,
+// account_id) match — the agent-only row is NOT used as a fallback,
+// because a paid personal-account subscription must not silently grant
+// paid-tier access to a B2B account the same agent belongs to. When
+// accountID is empty, the agent-only row (account_id = '' or IS NULL)
+// is matched. Among matches, latest updated_at wins; ties break on the
+// row's primary key id so output is deterministic. For schemas that
+// don't fit that shape, supply WithGORMResolver.
 type GORM struct {
 	db               *gorm.DB
 	table            string
@@ -111,7 +115,10 @@ func NewGORM(db *gorm.DB, opts ...GORMOption) *GORM {
 
 // GetSubscription resolves the claim for agentID (optionally scoped to
 // accountID). Returns (nil, nil) for "no record"; an error for actual
-// database failures or a nil database.
+// database failures, a nil database, or a returned claim whose status
+// doesn't match the closed set of SubscriptionStatus values (which would
+// otherwise silently propagate a misconfigured row or buggy resolver
+// into the issued JWT).
 func (g *GORM) GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
 	if g.db == nil {
 		return nil, errors.New("gorm: database is nil")
@@ -119,37 +126,44 @@ func (g *GORM) GetSubscription(ctx context.Context, agentID, accountID string) (
 	if agentID == "" {
 		return nil, errors.New("gorm: agentID must not be empty")
 	}
+	var (
+		claim *auth.SubscriptionClaim
+		err   error
+	)
 	if g.resolver != nil {
-		return g.resolver(ctx, g.db, agentID, accountID)
+		claim, err = g.resolver(ctx, g.db, agentID, accountID)
+	} else {
+		claim, err = g.defaultLookup(ctx, agentID, accountID)
 	}
-	return g.defaultLookup(ctx, agentID, accountID)
+	if err != nil || claim == nil {
+		return claim, err
+	}
+	if !claim.Status.Valid() {
+		return nil, fmt.Errorf("gorm: invalid subscription status %q for agent %s", claim.Status, agentID)
+	}
+	return claim, nil
 }
 
 func (g *GORM) defaultLookup(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
 	var rec SubscriptionRecord
-	q := g.db.WithContext(ctx).Table(g.table).Where("agent_id = ?", agentID)
+	base := g.db.WithContext(ctx).Table(g.table).Where("agent_id = ?", agentID)
 
-	// Prefer an exact account match when one was requested. Fall back to
-	// the latest agent-scoped row only if no account-scoped row exists,
-	// so a paid personal-account subscription doesn't accidentally apply
-	// to a B2B account the same agent belongs to.
 	if accountID != "" {
-		err := q.Where("account_id = ?", accountID).
-			Order("updated_at DESC").
+		err := base.Where("account_id = ?", accountID).
+			Order("updated_at DESC, id DESC").
 			Limit(1).
 			Take(&rec).Error
-		if err == nil {
-			return g.toClaim(rec), nil
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
 		}
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
+		if err != nil {
 			return nil, fmt.Errorf("gorm: query account-scoped subscription: %w", err)
 		}
+		return g.toClaim(rec), nil
 	}
 
-	err := g.db.WithContext(ctx).
-		Table(g.table).
-		Where("agent_id = ? AND (account_id = ? OR account_id IS NULL)", agentID, "").
-		Order("updated_at DESC").
+	err := base.Where("account_id = ? OR account_id IS NULL", "").
+		Order("updated_at DESC, id DESC").
 		Limit(1).
 		Take(&rec).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -20,8 +20,8 @@ const (
 // WithGORMTable; for fully custom schemas use WithGORMResolver.
 type SubscriptionRecord struct {
 	ID        uint       `gorm:"primaryKey"`
-	AgentID   string     `gorm:"size:64;index:idx_sub_agent;not null"`
-	AccountID string     `gorm:"size:64;index:idx_sub_agent_account"`
+	AgentID   string     `gorm:"size:64;index:idx_sub_agent_account,priority:1;not null"`
+	AccountID string     `gorm:"size:64;index:idx_sub_agent_account,priority:2"`
 	Status    string     `gorm:"size:32;not null"`
 	Plan      string     `gorm:"size:128"`
 	Provider  string     `gorm:"size:64"`
@@ -162,7 +162,7 @@ func (g *GORM) defaultLookup(ctx context.Context, agentID, accountID string) (*a
 		return g.toClaim(rec), nil
 	}
 
-	err := base.Where("account_id = ? OR account_id IS NULL", "").
+	err := base.Where("(account_id = ? OR account_id IS NULL)", "").
 		Order("updated_at DESC, id DESC").
 		Limit(1).
 		Take(&rec).Error

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -1,0 +1,178 @@
+package subscription
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	"gorm.io/gorm"
+)
+
+const (
+	gormDefaultTable = "subscriptions"
+)
+
+// SubscriptionRecord is the default row shape the GORM adapter reads from.
+// Consumer services that already own a billing projection can either
+// AutoMigrate this struct into their schema or override the table name via
+// WithGORMTable; for fully custom schemas use WithGORMResolver.
+type SubscriptionRecord struct {
+	ID        uint       `gorm:"primaryKey"`
+	AgentID   string     `gorm:"size:64;index:idx_sub_agent;not null"`
+	AccountID string     `gorm:"size:64;index:idx_sub_agent_account"`
+	Status    string     `gorm:"size:32;not null"`
+	Plan      string     `gorm:"size:128"`
+	Provider  string     `gorm:"size:64"`
+	ExpiresAt *time.Time
+	UpdatedAt time.Time
+}
+
+// TableName returns the default table name. Overridden in queries via
+// WithGORMTable rather than tag-based reflection so the same struct can
+// back differently-named tables in different services.
+func (SubscriptionRecord) TableName() string { return gormDefaultTable }
+
+// Resolver is the fully-custom-query escape hatch. When provided via
+// WithGORMResolver the adapter delegates entirely to the function and
+// ignores the default schema; that lets services with bespoke billing
+// projections plug in arbitrary SQL/GORM joins without forking the
+// adapter.
+type Resolver func(ctx context.Context, db *gorm.DB, agentID, accountID string) (*auth.SubscriptionClaim, error)
+
+// GORMOption configures a GORM adapter.
+type GORMOption func(*GORM)
+
+// WithGORMTable overrides the table name the default resolver queries.
+// Only meaningful when no custom resolver is configured.
+func WithGORMTable(name string) GORMOption {
+	return func(g *GORM) {
+		if name != "" {
+			g.table = name
+		}
+	}
+}
+
+// WithGORMResolver replaces the default row-based lookup with a caller-
+// supplied function. The function receives the *gorm.DB the adapter was
+// constructed with and is responsible for returning a normalized
+// SubscriptionClaim or (nil, nil) for "no record".
+func WithGORMResolver(r Resolver) GORMOption {
+	return func(g *GORM) {
+		if r != nil {
+			g.resolver = r
+		}
+	}
+}
+
+// WithGORMProvider overrides the Provider string stamped onto claims that
+// the default resolver constructs. Default is "gorm" — services that
+// already populate the row's provider column should stick with the default
+// (the row value wins when present); the option exists for projections
+// that don't store provider per-row.
+func WithGORMProvider(name string) GORMOption {
+	return func(g *GORM) {
+		if name != "" {
+			g.providerFallback = name
+		}
+	}
+}
+
+// GORM resolves SubscriptionClaim values from a relational projection
+// owned by the consumer service. Implements application.SubscriptionService.
+//
+// The default resolver expects a table matching SubscriptionRecord and
+// picks, for the given (agentID, accountID), the row with the latest
+// updated_at — preferring an exact account match when accountID is
+// non-empty, falling back to the agent-only row otherwise. For schemas
+// that don't fit that shape, supply WithGORMResolver.
+type GORM struct {
+	db               *gorm.DB
+	table            string
+	resolver         Resolver
+	providerFallback string
+}
+
+// NewGORM returns a GORM adapter backed by db. The default lookup queries
+// the "subscriptions" table; pass WithGORMTable or WithGORMResolver to
+// adapt to a different schema.
+func NewGORM(db *gorm.DB, opts ...GORMOption) *GORM {
+	g := &GORM{
+		db:               db,
+		table:            gormDefaultTable,
+		providerFallback: "gorm",
+	}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
+}
+
+// GetSubscription resolves the claim for agentID (optionally scoped to
+// accountID). Returns (nil, nil) for "no record"; an error for actual
+// database failures or a nil database.
+func (g *GORM) GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+	if g.db == nil {
+		return nil, errors.New("gorm: database is nil")
+	}
+	if agentID == "" {
+		return nil, errors.New("gorm: agentID must not be empty")
+	}
+	if g.resolver != nil {
+		return g.resolver(ctx, g.db, agentID, accountID)
+	}
+	return g.defaultLookup(ctx, agentID, accountID)
+}
+
+func (g *GORM) defaultLookup(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+	var rec SubscriptionRecord
+	q := g.db.WithContext(ctx).Table(g.table).Where("agent_id = ?", agentID)
+
+	// Prefer an exact account match when one was requested. Fall back to
+	// the latest agent-scoped row only if no account-scoped row exists,
+	// so a paid personal-account subscription doesn't accidentally apply
+	// to a B2B account the same agent belongs to.
+	if accountID != "" {
+		err := q.Where("account_id = ?", accountID).
+			Order("updated_at DESC").
+			Limit(1).
+			Take(&rec).Error
+		if err == nil {
+			return g.toClaim(rec), nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("gorm: query account-scoped subscription: %w", err)
+		}
+	}
+
+	err := g.db.WithContext(ctx).
+		Table(g.table).
+		Where("agent_id = ? AND (account_id = ? OR account_id IS NULL)", agentID, "").
+		Order("updated_at DESC").
+		Limit(1).
+		Take(&rec).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("gorm: query subscription: %w", err)
+	}
+	return g.toClaim(rec), nil
+}
+
+func (g *GORM) toClaim(rec SubscriptionRecord) *auth.SubscriptionClaim {
+	provider := rec.Provider
+	if provider == "" {
+		provider = g.providerFallback
+	}
+	claim := &auth.SubscriptionClaim{
+		Status:   auth.SubscriptionStatus(rec.Status),
+		Plan:     rec.Plan,
+		Provider: provider,
+	}
+	if rec.ExpiresAt != nil {
+		claim.ExpiresAt = rec.ExpiresAt.UTC()
+	}
+	return claim
+}

--- a/pkg/auth/infrastructure/subscription/gorm_test.go
+++ b/pkg/auth/infrastructure/subscription/gorm_test.go
@@ -119,13 +119,19 @@ func TestGORM_AccountScopedPreferredOverAgentOnly(t *testing.T) {
 	if claim.Plan != "team_free" {
 		t.Errorf("Plan = %q, want team_free (account-scoped row wins over agent-only)", claim.Plan)
 	}
+	if claim.Status != auth.SubscriptionStatusInactive {
+		// Pin the status to the team-scoped row so a regression that
+		// blends results between rows would surface here.
+		t.Errorf("Status = %q, want inactive (team row's status, not personal row's active)", claim.Status)
+	}
 }
 
-func TestGORM_NoAccountMatch_FallsBackToAgentOnly(t *testing.T) {
-	// When the requested account has no row but the agent has an
-	// agent-only row, the fallback returns it. (B2B account inherits
-	// the agent's personal subscription only when no team-scoped row
-	// exists.)
+func TestGORM_NonEmptyAccountWithNoMatch_ReturnsNil(t *testing.T) {
+	// Critical invariant: a paid personal-account subscription must NOT
+	// silently grant paid-tier access to a B2B/team account the same
+	// agent belongs to. When accountID is non-empty and no
+	// account-scoped row exists, the lookup returns (nil, nil) — it
+	// does not fall back to the agent-only personal row.
 	t.Parallel()
 
 	db := newGormTestDB(t)
@@ -143,11 +149,8 @@ func TestGORM_NoAccountMatch_FallsBackToAgentOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSubscription error: %v", err)
 	}
-	if claim == nil {
-		t.Fatal("expected agent-only fallback claim")
-	}
-	if claim.Plan != "personal" {
-		t.Errorf("Plan = %q, want personal", claim.Plan)
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v — personal subscription must not leak across account scope", claim)
 	}
 }
 
@@ -293,7 +296,7 @@ func TestGORM_EmptyAgentID_Errors(t *testing.T) {
 	}
 }
 
-func TestGORM_NilExpiresAt_ZeroOnClaim(t *testing.T) {
+func TestGORM_NilExpiresAt_ZeroOnClaim_ActiveLifetime(t *testing.T) {
 	t.Parallel()
 
 	db := newGormTestDB(t)
@@ -312,5 +315,170 @@ func TestGORM_NilExpiresAt_ZeroOnClaim(t *testing.T) {
 	}
 	if !claim.ExpiresAt.IsZero() {
 		t.Errorf("ExpiresAt = %v, want zero for nil row.expires_at", claim.ExpiresAt)
+	}
+	if !claim.IsActive() {
+		t.Error("IsActive() = false, want true for active lifetime claim with no expiry")
+	}
+}
+
+func TestGORM_NullAccountID_MatchedInAgentOnlyLookup(t *testing.T) {
+	// Schemas that store account_id as nullable rather than empty string
+	// must still match the agent-only fallback. Seed with raw SQL because
+	// the default *string SubscriptionRecord schema writes "" for the
+	// zero value.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	if err := db.Exec(
+		"INSERT INTO subscriptions (agent_id, account_id, status, plan, updated_at) VALUES (?, NULL, ?, ?, ?)",
+		"agent-1", "active", "pro", time.Now(),
+	).Error; err != nil {
+		t.Fatalf("seed via raw SQL: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected claim for NULL account_id row")
+	}
+	if claim.Plan != "pro" {
+		t.Errorf("Plan = %q, want pro", claim.Plan)
+	}
+}
+
+func TestGORM_NoMatchAtAll_ReturnsNil(t *testing.T) {
+	// A different agent has a row; agent-1 has none. Both lookups must
+	// miss and the function returns (nil, nil) without surfacing
+	// gorm.ErrRecordNotFound to the caller.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-other", AccountID: "team-1",
+		Status: "active", Plan: "pro", UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+}
+
+func TestGORM_DBError_NotSwallowed(t *testing.T) {
+	// Closing the underlying DB causes any subsequent query to return a
+	// non-ErrRecordNotFound error. Adapter must propagate it (caller
+	// distinguishes "no record" from "lookup failed").
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get *sql.DB: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close DB: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+
+	for _, accountID := range []string{"", "team-1"} {
+		_, err := g.GetSubscription(context.Background(), "agent-1", accountID)
+		if err == nil {
+			t.Errorf("accountID=%q: expected error, got nil", accountID)
+		}
+	}
+}
+
+func TestGORM_RowProvider_WinsOverFallbackOption(t *testing.T) {
+	// Pin the documented contract: when the row's provider column is
+	// non-empty, WithGORMProvider's fallback is ignored.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", Status: "active", Plan: "pro",
+		Provider: "stripe", UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMProvider("internal"))
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Provider != "stripe" {
+		t.Errorf("Provider = %q, want stripe (row value must win over WithGORMProvider fallback)", claim.Provider)
+	}
+}
+
+func TestGORM_EmptyAgentID_ResolverNotInvoked(t *testing.T) {
+	// The empty-agentID guard must run before resolver dispatch — a
+	// custom resolver should never see an empty agentID.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	called := false
+	g := subscription.NewGORM(db, subscription.WithGORMResolver(func(ctx context.Context, _ *gorm.DB, _, _ string) (*auth.SubscriptionClaim, error) {
+		called = true
+		return nil, nil
+	}))
+	if _, err := g.GetSubscription(context.Background(), "", "team-1"); err == nil {
+		t.Fatal("expected error for empty agent ID")
+	}
+	if called {
+		t.Error("resolver was invoked despite empty agentID")
+	}
+}
+
+func TestGORM_InvalidStatusFromResolver_ReturnsError(t *testing.T) {
+	// A buggy resolver returning a non-canonical status (wrong case,
+	// typo, etc.) must not silently propagate into a JWT — the adapter
+	// surfaces it as an error so it lands in the caller's log.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	g := subscription.NewGORM(db, subscription.WithGORMResolver(func(_ context.Context, _ *gorm.DB, _, _ string) (*auth.SubscriptionClaim, error) {
+		return &auth.SubscriptionClaim{Status: "ACTIVE"}, nil
+	}))
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim on invalid status, got %+v", claim)
+	}
+}
+
+func TestGORM_InvalidStatusFromRow_ReturnsError(t *testing.T) {
+	// Same defense from the default-row path.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", Status: "ACTIVE", Plan: "pro", UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
 	}
 }

--- a/pkg/auth/infrastructure/subscription/gorm_test.go
+++ b/pkg/auth/infrastructure/subscription/gorm_test.go
@@ -1,0 +1,316 @@
+package subscription_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/subscription"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var _ application.SubscriptionService = (*subscription.GORM)(nil)
+
+func newGormTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&subscription.SubscriptionRecord{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func TestGORM_NoRecord_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	g := subscription.NewGORM(db)
+
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+}
+
+func TestGORM_AgentOnlyMatch(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	expires := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	row := &subscription.SubscriptionRecord{
+		AgentID:   "agent-1",
+		AccountID: "",
+		Status:    string(auth.SubscriptionStatusActive),
+		Plan:      "pro",
+		Provider:  "stripe",
+		ExpiresAt: &expires,
+		UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected claim")
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want active", claim.Status)
+	}
+	if claim.Plan != "pro" {
+		t.Errorf("Plan = %q, want pro", claim.Plan)
+	}
+	if claim.Provider != "stripe" {
+		t.Errorf("Provider = %q, want stripe (row value wins over fallback)", claim.Provider)
+	}
+	if !claim.ExpiresAt.Equal(expires) {
+		t.Errorf("ExpiresAt = %v, want %v", claim.ExpiresAt, expires)
+	}
+}
+
+func TestGORM_AccountScopedPreferredOverAgentOnly(t *testing.T) {
+	// A paid subscription on the agent's personal account must not
+	// automatically apply to a B2B account the agent also belongs to —
+	// the account-scoped row wins when accountID is requested.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	now := time.Now()
+	rows := []*subscription.SubscriptionRecord{
+		{
+			AgentID: "agent-1", AccountID: "",
+			Status: string(auth.SubscriptionStatusActive), Plan: "personal",
+			UpdatedAt: now.Add(-time.Hour),
+		},
+		{
+			AgentID: "agent-1", AccountID: "team-1",
+			Status: string(auth.SubscriptionStatusInactive), Plan: "team_free",
+			UpdatedAt: now,
+		},
+	}
+	for _, r := range rows {
+		if err := db.Create(r).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "team_free" {
+		t.Errorf("Plan = %q, want team_free (account-scoped row wins over agent-only)", claim.Plan)
+	}
+}
+
+func TestGORM_NoAccountMatch_FallsBackToAgentOnly(t *testing.T) {
+	// When the requested account has no row but the agent has an
+	// agent-only row, the fallback returns it. (B2B account inherits
+	// the agent's personal subscription only when no team-scoped row
+	// exists.)
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", AccountID: "",
+		Status: string(auth.SubscriptionStatusActive), Plan: "personal",
+		UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-without-row")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected agent-only fallback claim")
+	}
+	if claim.Plan != "personal" {
+		t.Errorf("Plan = %q, want personal", claim.Plan)
+	}
+}
+
+func TestGORM_LatestUpdatedAtWins(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	now := time.Now()
+	rows := []*subscription.SubscriptionRecord{
+		{AgentID: "agent-1", Status: "active", Plan: "old", UpdatedAt: now.Add(-2 * time.Hour)},
+		{AgentID: "agent-1", Status: "active", Plan: "new", UpdatedAt: now},
+		{AgentID: "agent-1", Status: "active", Plan: "older", UpdatedAt: now.Add(-1 * time.Hour)},
+	}
+	for _, r := range rows {
+		if err := db.Create(r).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "new" {
+		t.Errorf("Plan = %q, want new (latest updated_at)", claim.Plan)
+	}
+}
+
+func TestGORM_ProviderFallback(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", Status: "active", Plan: "pro",
+		UpdatedAt: time.Now(),
+		// Provider intentionally empty
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMProvider("internal"))
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Provider != "internal" {
+		t.Errorf("Provider = %q, want internal (fallback applied when row provider is empty)", claim.Provider)
+	}
+}
+
+func TestGORM_CustomTable(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	if err := db.Exec(`CREATE TABLE custom_subs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		agent_id TEXT,
+		account_id TEXT,
+		status TEXT,
+		plan TEXT,
+		provider TEXT,
+		expires_at DATETIME,
+		updated_at DATETIME
+	)`).Error; err != nil {
+		t.Fatalf("create custom table: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO custom_subs (agent_id, account_id, status, plan, provider, updated_at) VALUES ('agent-1','','active','pro','stripe',?)`, time.Now()).Error; err != nil {
+		t.Fatalf("seed custom: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMTable("custom_subs"))
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil || claim.Plan != "pro" {
+		t.Errorf("claim = %+v, want plan=pro", claim)
+	}
+}
+
+func TestGORM_ResolverEscapeHatch(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	calledArgs := struct {
+		agentID, accountID string
+	}{}
+	resolver := func(ctx context.Context, db *gorm.DB, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+		calledArgs.agentID = agentID
+		calledArgs.accountID = accountID
+		return &auth.SubscriptionClaim{
+			Status:   auth.SubscriptionStatusActive,
+			Plan:     "from-resolver",
+			Provider: "custom",
+		}, nil
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMResolver(resolver))
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if calledArgs.agentID != "agent-1" || calledArgs.accountID != "team-1" {
+		t.Errorf("resolver called with %+v, want {agent-1, team-1}", calledArgs)
+	}
+	if claim.Plan != "from-resolver" {
+		t.Errorf("Plan = %q, want from-resolver", claim.Plan)
+	}
+}
+
+func TestGORM_ResolverPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	bang := errors.New("backend boom")
+	g := subscription.NewGORM(db, subscription.WithGORMResolver(func(ctx context.Context, db *gorm.DB, _, _ string) (*auth.SubscriptionClaim, error) {
+		return nil, bang
+	}))
+	_, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if !errors.Is(err, bang) {
+		t.Errorf("err = %v, want %v wrapped", err, bang)
+	}
+}
+
+func TestGORM_NilDB_Errors(t *testing.T) {
+	t.Parallel()
+
+	g := subscription.NewGORM(nil)
+	if _, err := g.GetSubscription(context.Background(), "agent-1", ""); err == nil {
+		t.Fatal("expected error for nil DB")
+	}
+}
+
+func TestGORM_EmptyAgentID_Errors(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	g := subscription.NewGORM(db)
+	if _, err := g.GetSubscription(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error for empty agent ID")
+	}
+}
+
+func TestGORM_NilExpiresAt_ZeroOnClaim(t *testing.T) {
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", Status: "active", Plan: "lifetime",
+		ExpiresAt: nil, UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db)
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if !claim.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt = %v, want zero for nil row.expires_at", claim.ExpiresAt)
+	}
+}

--- a/pkg/auth/infrastructure/subscription/revenuecat.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat.go
@@ -111,9 +111,11 @@ type revenueCatSubscription struct {
 // GetSubscription queries RevenueCat for agentID's current subscription
 // state. accountID is unused — RevenueCat keys on a single app_user_id, so
 // callers should arrange to use agentID consistently across registration
-// and lookup. Returns (nil, nil) when the subscriber has no active or
-// recently-active entitlement; returns an error for transport failures and
-// non-2xx responses other than 404 (which is also treated as "no record").
+// and lookup. Returns (nil, nil) when RevenueCat has no record for the
+// subscriber (404) or when there is no entitlement data to build a claim.
+// Expired entitlements may still produce a non-nil claim with inactive
+// status. Returns an error for transport failures and non-2xx responses
+// other than 404.
 func (r *RevenueCat) GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
 	_ = accountID
 	if r.apiKey == "" {
@@ -246,7 +248,6 @@ type subscriptionSignals struct {
 	isTrial               bool
 	unsubscribedAt        *time.Time
 	unsubscribedExpiresAt *time.Time
-	matchedHadUnsubscribe bool
 }
 
 func readSubscriptionSignals(all map[string]revenueCatSubscription, matched revenueCatSubscription, hasMatch bool) subscriptionSignals {
@@ -256,7 +257,6 @@ func readSubscriptionSignals(all map[string]revenueCatSubscription, matched reve
 		s.isTrial = matched.PeriodType == "trial"
 		s.unsubscribedAt = matched.UnsubscribeDetectedAt
 		s.unsubscribedExpiresAt = matched.ExpiresDate
-		s.matchedHadUnsubscribe = matched.UnsubscribeDetectedAt != nil
 		return s
 	}
 	for _, sub := range all {

--- a/pkg/auth/infrastructure/subscription/revenuecat.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat.go
@@ -1,0 +1,225 @@
+// Package subscription contains application.SubscriptionService adapters for
+// concrete billing providers. Each adapter normalizes provider-specific
+// subscription state into auth.SubscriptionClaim so consumer services see a
+// uniform shape regardless of the billing backend.
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+)
+
+const (
+	revenueCatDefaultBaseURL = "https://api.revenuecat.com/v1"
+	revenueCatProvider       = "revenuecat"
+)
+
+// RevenueCatOption configures a RevenueCat adapter.
+type RevenueCatOption func(*RevenueCat)
+
+// WithRevenueCatBaseURL overrides the API base URL. Primarily used by tests
+// pointing at httptest servers; production wiring uses the default.
+func WithRevenueCatBaseURL(u string) RevenueCatOption {
+	return func(r *RevenueCat) {
+		if u != "" {
+			r.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithRevenueCatHTTPClient overrides the HTTP client. Use this to plumb a
+// shared client with timeouts, retries, or instrumentation. The default
+// client has a 5-second timeout, which is short enough that a wedged
+// billing API still returns control to IssueIdentityToken before the user
+// gives up on login.
+func WithRevenueCatHTTPClient(c *http.Client) RevenueCatOption {
+	return func(r *RevenueCat) {
+		if c != nil {
+			r.client = c
+		}
+	}
+}
+
+// WithRevenueCatNow overrides the time source used to decide whether an
+// entitlement's expiry is in the past. Tests inject a deterministic clock;
+// production uses time.Now.
+func WithRevenueCatNow(now func() time.Time) RevenueCatOption {
+	return func(r *RevenueCat) {
+		if now != nil {
+			r.now = now
+		}
+	}
+}
+
+// RevenueCat resolves SubscriptionClaim values from the RevenueCat REST API.
+// It implements application.SubscriptionService.
+type RevenueCat struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+	now     func() time.Time
+}
+
+// NewRevenueCat returns a RevenueCat adapter authenticated with apiKey
+// (the project's secret API key). An empty apiKey is permitted at
+// construction time but every GetSubscription call will fail until set.
+func NewRevenueCat(apiKey string, opts ...RevenueCatOption) *RevenueCat {
+	r := &RevenueCat{
+		apiKey:  apiKey,
+		baseURL: revenueCatDefaultBaseURL,
+		client:  &http.Client{Timeout: 5 * time.Second},
+		now:     time.Now,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// revenueCatResponse is the trimmed shape of GET /v1/subscribers/{app_user_id}.
+// Only the fields the adapter consumes are decoded; the rest of RevenueCat's
+// response is preserved opaquely in SubscriptionClaim.Metadata via
+// raw_entitlements when the caller wants provider-native data.
+type revenueCatResponse struct {
+	Subscriber struct {
+		Entitlements  map[string]revenueCatEntitlement  `json:"entitlements"`
+		Subscriptions map[string]revenueCatSubscription `json:"subscriptions"`
+	} `json:"subscriber"`
+}
+
+type revenueCatEntitlement struct {
+	ExpiresDate       *time.Time `json:"expires_date"`
+	ProductIdentifier string     `json:"product_identifier"`
+	PurchaseDate      *time.Time `json:"purchase_date"`
+}
+
+type revenueCatSubscription struct {
+	ExpiresDate             *time.Time `json:"expires_date"`
+	BillingIssuesDetectedAt *time.Time `json:"billing_issues_detected_at"`
+	UnsubscribeDetectedAt   *time.Time `json:"unsubscribe_detected_at"`
+	PeriodType              string     `json:"period_type"`
+	Store                   string     `json:"store"`
+}
+
+// GetSubscription queries RevenueCat for agentID's current subscription
+// state. accountID is unused — RevenueCat keys on a single app_user_id, so
+// callers should arrange to use agentID consistently across registration
+// and lookup. Returns (nil, nil) when the subscriber has no active or
+// recently-active entitlement; returns an error for transport failures and
+// non-2xx responses other than 404 (which is also treated as "no record").
+func (r *RevenueCat) GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+	_ = accountID
+	if r.apiKey == "" {
+		return nil, errors.New("revenuecat: missing API key")
+	}
+	if agentID == "" {
+		return nil, errors.New("revenuecat: agentID must not be empty")
+	}
+
+	url := fmt.Sprintf("%s/subscribers/%s", r.baseURL, agentID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("revenuecat: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("revenuecat: http call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("revenuecat: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded revenueCatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("revenuecat: decode response: %w", err)
+	}
+
+	return r.toClaim(decoded), nil
+}
+
+// toClaim picks the best entitlement (latest expiry, ties broken by name)
+// and maps it to a SubscriptionClaim. Returns nil when the subscriber has
+// no entitlements at all — RevenueCat returns 200 with empty maps for
+// users who exist in the project but have never purchased.
+func (r *RevenueCat) toClaim(resp revenueCatResponse) *auth.SubscriptionClaim {
+	if len(resp.Subscriber.Entitlements) == 0 {
+		return nil
+	}
+
+	now := r.now()
+	var (
+		bestName   string
+		bestExpiry time.Time
+		bestEnt    revenueCatEntitlement
+		hasUnbound bool // true when the chosen entitlement has nil expires_date (lifetime)
+	)
+	for name, ent := range resp.Subscriber.Entitlements {
+		if ent.ExpiresDate == nil {
+			// Lifetime entitlements always win over any time-bounded one.
+			if !hasUnbound || name < bestName {
+				bestName = name
+				bestEnt = ent
+				bestExpiry = time.Time{}
+				hasUnbound = true
+			}
+			continue
+		}
+		if hasUnbound {
+			continue
+		}
+		if bestName == "" || ent.ExpiresDate.After(bestExpiry) || (ent.ExpiresDate.Equal(bestExpiry) && name < bestName) {
+			bestName = name
+			bestEnt = ent
+			bestExpiry = *ent.ExpiresDate
+		}
+	}
+
+	claim := &auth.SubscriptionClaim{
+		Plan:     bestName,
+		Provider: revenueCatProvider,
+		Metadata: map[string]any{
+			"product_identifier": bestEnt.ProductIdentifier,
+		},
+	}
+	if !hasUnbound {
+		claim.ExpiresAt = bestExpiry
+	}
+
+	// Status mapping prefers signals from the underlying subscription row
+	// (period_type == "trial", billing_issues_detected_at set) over the
+	// raw entitlement-expiry check, because RevenueCat surfaces those
+	// signals on the subscription, not the entitlement.
+	sub, hasSub := resp.Subscriber.Subscriptions[bestEnt.ProductIdentifier]
+	switch {
+	case !hasUnbound && now.After(bestExpiry):
+		claim.Status = auth.SubscriptionStatusInactive
+	case hasSub && sub.BillingIssuesDetectedAt != nil:
+		claim.Status = auth.SubscriptionStatusPastDue
+	case hasSub && sub.PeriodType == "trial":
+		claim.Status = auth.SubscriptionStatusTrialing
+	default:
+		claim.Status = auth.SubscriptionStatusActive
+	}
+
+	if hasSub && sub.Store != "" {
+		claim.Metadata["store"] = sub.Store
+	}
+	return claim
+}

--- a/pkg/auth/infrastructure/subscription/revenuecat.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -85,9 +86,7 @@ func NewRevenueCat(apiKey string, opts ...RevenueCatOption) *RevenueCat {
 }
 
 // revenueCatResponse is the trimmed shape of GET /v1/subscribers/{app_user_id}.
-// Only the fields the adapter consumes are decoded; the rest of RevenueCat's
-// response is preserved opaquely in SubscriptionClaim.Metadata via
-// raw_entitlements when the caller wants provider-native data.
+// Only the fields the adapter consumes are decoded.
 type revenueCatResponse struct {
 	Subscriber struct {
 		Entitlements  map[string]revenueCatEntitlement  `json:"entitlements"`
@@ -124,8 +123,8 @@ func (r *RevenueCat) GetSubscription(ctx context.Context, agentID, accountID str
 		return nil, errors.New("revenuecat: agentID must not be empty")
 	}
 
-	url := fmt.Sprintf("%s/subscribers/%s", r.baseURL, agentID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	endpoint := fmt.Sprintf("%s/subscribers/%s", r.baseURL, url.PathEscape(agentID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("revenuecat: build request: %w", err)
 	}
@@ -203,16 +202,29 @@ func (r *RevenueCat) toClaim(resp revenueCatResponse) *auth.SubscriptionClaim {
 	}
 
 	// Status mapping prefers signals from the underlying subscription row
-	// (period_type == "trial", billing_issues_detected_at set) over the
-	// raw entitlement-expiry check, because RevenueCat surfaces those
-	// signals on the subscription, not the entitlement.
+	// (unsubscribe_detected_at, billing_issues_detected_at, period_type)
+	// over the raw entitlement-expiry check. RevenueCat surfaces those
+	// signals on the subscription, not the entitlement; multi-SKU
+	// offerings, upgrades, and promo-code grants can leave the
+	// entitlement's product_identifier pointing at a SKU that isn't keyed
+	// directly in the Subscriptions map, so a missed direct lookup falls
+	// back to scanning all rows for the worst signal rather than silently
+	// reporting Active.
 	sub, hasSub := resp.Subscriber.Subscriptions[bestEnt.ProductIdentifier]
+	signals := readSubscriptionSignals(resp.Subscriber.Subscriptions, sub, hasSub)
+
 	switch {
 	case !hasUnbound && now.After(bestExpiry):
 		claim.Status = auth.SubscriptionStatusInactive
-	case hasSub && sub.BillingIssuesDetectedAt != nil:
+	case signals.unsubscribedAndExpired(now):
+		// Refunded / revoked: provider says they no longer have access,
+		// not just "auto-renew off". For time-bounded subscriptions still
+		// in their paid window this branch does not fire — IsActive stays
+		// true until the entitlement actually lapses.
+		claim.Status = auth.SubscriptionStatusInactive
+	case signals.hasBillingIssues:
 		claim.Status = auth.SubscriptionStatusPastDue
-	case hasSub && sub.PeriodType == "trial":
+	case signals.isTrial:
 		claim.Status = auth.SubscriptionStatusTrialing
 	default:
 		claim.Status = auth.SubscriptionStatusActive
@@ -222,4 +234,56 @@ func (r *RevenueCat) toClaim(resp revenueCatResponse) *auth.SubscriptionClaim {
 		claim.Metadata["store"] = sub.Store
 	}
 	return claim
+}
+
+// subscriptionSignals collapses the set of subscription rows down to the
+// boolean signals the status switch cares about. The matched row (when
+// present) wins because it's the one tied to the chosen entitlement; we
+// fall back to scanning all rows so a billing-issue or unsubscribe on a
+// related-but-differently-keyed SKU isn't silently lost.
+type subscriptionSignals struct {
+	hasBillingIssues      bool
+	isTrial               bool
+	unsubscribedAt        *time.Time
+	unsubscribedExpiresAt *time.Time
+	matchedHadUnsubscribe bool
+}
+
+func readSubscriptionSignals(all map[string]revenueCatSubscription, matched revenueCatSubscription, hasMatch bool) subscriptionSignals {
+	var s subscriptionSignals
+	if hasMatch {
+		s.hasBillingIssues = matched.BillingIssuesDetectedAt != nil
+		s.isTrial = matched.PeriodType == "trial"
+		s.unsubscribedAt = matched.UnsubscribeDetectedAt
+		s.unsubscribedExpiresAt = matched.ExpiresDate
+		s.matchedHadUnsubscribe = matched.UnsubscribeDetectedAt != nil
+		return s
+	}
+	for _, sub := range all {
+		if sub.BillingIssuesDetectedAt != nil {
+			s.hasBillingIssues = true
+		}
+		if sub.PeriodType == "trial" {
+			s.isTrial = true
+		}
+		if sub.UnsubscribeDetectedAt != nil && s.unsubscribedAt == nil {
+			s.unsubscribedAt = sub.UnsubscribeDetectedAt
+			s.unsubscribedExpiresAt = sub.ExpiresDate
+		}
+	}
+	return s
+}
+
+// unsubscribedAndExpired reports whether the user has unsubscribed AND
+// either has no expiry or the expiry has passed — the conditions under
+// which RevenueCat indicates access should be revoked. A user who turned
+// off auto-renew but is still in their paid window stays active.
+func (s subscriptionSignals) unsubscribedAndExpired(now time.Time) bool {
+	if s.unsubscribedAt == nil {
+		return false
+	}
+	if s.unsubscribedExpiresAt == nil {
+		return true
+	}
+	return !s.unsubscribedExpiresAt.After(now)
 }

--- a/pkg/auth/infrastructure/subscription/revenuecat_test.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat_test.go
@@ -1,0 +1,337 @@
+package subscription_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/subscription"
+)
+
+// Adapter must satisfy the SubscriptionService interface.
+var _ application.SubscriptionService = (*subscription.RevenueCat)(nil)
+
+func fixedNow(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func TestRevenueCat_NoEntitlements_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/subscribers/agent-1") {
+			t.Errorf("path = %q, want suffix /subscribers/agent-1", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"subscriber":{"entitlements":{},"subscriptions":{}}}`))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat(
+		"test-key",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+	)
+
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Fatalf("expected nil claim for empty entitlements, got %+v", claim)
+	}
+}
+
+func TestRevenueCat_ActiveEntitlement(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(30 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {
+				"pro": {
+					"expires_date": "` + expires.Format(time.RFC3339) + `",
+					"product_identifier": "pro_monthly"
+				}
+			},
+			"subscriptions": {
+				"pro_monthly": {
+					"expires_date": "` + expires.Format(time.RFC3339) + `",
+					"period_type": "normal",
+					"store": "app_store"
+				}
+			}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected non-nil claim")
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusActive)
+	}
+	if claim.Plan != "pro" {
+		t.Errorf("Plan = %q, want %q", claim.Plan, "pro")
+	}
+	if claim.Provider != "revenuecat" {
+		t.Errorf("Provider = %q, want %q", claim.Provider, "revenuecat")
+	}
+	if !claim.ExpiresAt.Equal(expires) {
+		t.Errorf("ExpiresAt = %v, want %v", claim.ExpiresAt, expires)
+	}
+	if got := claim.Metadata["product_identifier"]; got != "pro_monthly" {
+		t.Errorf("Metadata[product_identifier] = %v, want pro_monthly", got)
+	}
+	if got := claim.Metadata["store"]; got != "app_store" {
+		t.Errorf("Metadata[store] = %v, want app_store", got)
+	}
+	if !claim.IsActive() {
+		t.Error("IsActive() = false, want true")
+	}
+}
+
+func TestRevenueCat_TrialPeriod_MarkedTrialing(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(7 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}},
+			"subscriptions": {"pro_monthly":{"expires_date":"` + expires.Format(time.RFC3339) + `","period_type":"trial"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusTrialing {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusTrialing)
+	}
+}
+
+func TestRevenueCat_BillingIssue_MarkedPastDue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(7 * 24 * time.Hour)
+	billing := now.Add(-1 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}},
+			"subscriptions": {"pro_monthly":{"expires_date":"` + expires.Format(time.RFC3339) + `","period_type":"normal","billing_issues_detected_at":"` + billing.Format(time.RFC3339) + `"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusPastDue {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusPastDue)
+	}
+}
+
+func TestRevenueCat_ExpiredEntitlement_MarkedInactive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-7 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expired.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}},
+			"subscriptions": {"pro_monthly":{"expires_date":"` + expired.Format(time.RFC3339) + `","period_type":"normal"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusInactive {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusInactive)
+	}
+	if claim.IsActive() {
+		t.Error("IsActive() = true, want false for expired entitlement")
+	}
+}
+
+func TestRevenueCat_LifetimeEntitlement_NoExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	body := `{"subscriber":{"entitlements":{"pro":{"expires_date":null,"product_identifier":"pro_lifetime"}},"subscriptions":{}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k", subscription.WithRevenueCatBaseURL(srv.URL))
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if !claim.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt = %v, want zero for lifetime entitlement", claim.ExpiresAt)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusActive)
+	}
+	if !claim.IsActive() {
+		t.Error("IsActive() = false, want true for lifetime entitlement")
+	}
+}
+
+func TestRevenueCat_MultipleEntitlements_PicksLatestExpiry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	earlier := now.Add(7 * 24 * time.Hour)
+	later := now.Add(60 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {
+				"basic": {"expires_date":"` + earlier.Format(time.RFC3339) + `","product_identifier":"basic_monthly"},
+				"pro":   {"expires_date":"` + later.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}
+			},
+			"subscriptions": {}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "pro" {
+		t.Errorf("Plan = %q, want pro (latest-expiring)", claim.Plan)
+	}
+	if !claim.ExpiresAt.Equal(later) {
+		t.Errorf("ExpiresAt = %v, want %v", claim.ExpiresAt, later)
+	}
+}
+
+func TestRevenueCat_NotFound_ReturnsNilNoError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k", subscription.WithRevenueCatBaseURL(srv.URL))
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim for 404, got %+v", claim)
+	}
+}
+
+func TestRevenueCat_NonOKStatus_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k", subscription.WithRevenueCatBaseURL(srv.URL))
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim on error, got %+v", claim)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %v, want it to mention 500", err)
+	}
+}
+
+func TestRevenueCat_MissingAPIKey_Errors(t *testing.T) {
+	t.Parallel()
+
+	rc := subscription.NewRevenueCat("")
+	if _, err := rc.GetSubscription(context.Background(), "agent-1", ""); err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestRevenueCat_EmptyAgentID_Errors(t *testing.T) {
+	t.Parallel()
+
+	rc := subscription.NewRevenueCat("k")
+	if _, err := rc.GetSubscription(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error for empty agent ID")
+	}
+}
+
+func TestRevenueCat_CancelledContext_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// never reached
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k", subscription.WithRevenueCatBaseURL(srv.URL))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := rc.GetSubscription(ctx, "agent-1", ""); err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/pkg/auth/infrastructure/subscription/revenuecat_test.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat_test.go
@@ -2,6 +2,7 @@ package subscription_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -333,5 +334,329 @@ func TestRevenueCat_CancelledContext_Errors(t *testing.T) {
 	cancel()
 	if _, err := rc.GetSubscription(ctx, "agent-1", ""); err == nil {
 		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestRevenueCat_LifetimeRevoked_MarkedInactive(t *testing.T) {
+	// Refunded / revoked lifetime: the entitlement is still in the
+	// response while RevenueCat propagates the change, but the
+	// subscription row carries unsubscribe_detected_at. The adapter
+	// must treat this as inactive instead of silently reporting Active.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	revoked := now.Add(-1 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":null,"product_identifier":"pro_lifetime"}},
+			"subscriptions": {"pro_lifetime":{"expires_date":null,"unsubscribe_detected_at":"` + revoked.Format(time.RFC3339) + `"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusInactive {
+		t.Errorf("Status = %q, want %q for revoked lifetime", claim.Status, auth.SubscriptionStatusInactive)
+	}
+	if claim.IsActive() {
+		t.Error("IsActive() = true, want false for revoked lifetime")
+	}
+}
+
+func TestRevenueCat_UnsubscribeButStillInPaidWindow_StaysActive(t *testing.T) {
+	// User turned off auto-renew but the paid period hasn't lapsed yet.
+	// They should keep paid-tier access until expires_date.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(7 * 24 * time.Hour)
+	turnedOff := now.Add(-3 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}},
+			"subscriptions": {"pro_monthly":{"expires_date":"` + expires.Format(time.RFC3339) + `","unsubscribe_detected_at":"` + turnedOff.Format(time.RFC3339) + `"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q while still in paid window", claim.Status, auth.SubscriptionStatusActive)
+	}
+}
+
+func TestRevenueCat_BillingIssueOnUnmatchedSubscription_StillSurfaces(t *testing.T) {
+	// Entitlement product_identifier doesn't match the subscription row's
+	// key (multi-SKU offering, upgrade in flight). The fallback scan
+	// must still surface the billing-issues signal rather than reporting
+	// Active.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(7 * 24 * time.Hour)
+	billing := now.Add(-1 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"pro_annual"}},
+			"subscriptions": {"pro_monthly":{"expires_date":"` + expires.Format(time.RFC3339) + `","billing_issues_detected_at":"` + billing.Format(time.RFC3339) + `"}}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusPastDue {
+		t.Errorf("Status = %q, want %q (fallback scan should surface unmatched billing issue)", claim.Status, auth.SubscriptionStatusPastDue)
+	}
+}
+
+func TestRevenueCat_TimeBoundedNoMatchingSubscription_Active(t *testing.T) {
+	// Entitlement granted via promo code with no purchase row. Status
+	// should default to Active rather than panic on the missing key.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(30 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {"pro":{"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"pro_monthly"}},
+			"subscriptions": {}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want Active for entitlement with no subscription row", claim.Status)
+	}
+	if _, ok := claim.Metadata["store"]; ok {
+		t.Errorf("store metadata should be absent without matching subscription, got %v", claim.Metadata["store"])
+	}
+}
+
+func TestRevenueCat_LifetimeAndBoundedCoexist_LifetimeWins(t *testing.T) {
+	// Common shape after an upgrade: the bounded subscription is still
+	// in the response while the lifetime entitlement supersedes it.
+	// Lifetime must win regardless of map iteration order, so we run
+	// the assertion several times to defeat luck.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(60 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {
+				"pro_lifetime": {"expires_date":null,"product_identifier":"lifetime_sku"},
+				"pro_monthly":  {"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"monthly_sku"}
+			},
+			"subscriptions": {}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+
+	for i := 0; i < 10; i++ {
+		claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+		if err != nil {
+			t.Fatalf("GetSubscription error: %v", err)
+		}
+		if claim.Plan != "pro_lifetime" {
+			t.Fatalf("Plan = %q, want pro_lifetime (iteration %d)", claim.Plan, i)
+		}
+		if !claim.ExpiresAt.IsZero() {
+			t.Fatalf("ExpiresAt = %v, want zero for lifetime (iteration %d)", claim.ExpiresAt, i)
+		}
+	}
+}
+
+func TestRevenueCat_TieBreakByName_PicksLexFirst(t *testing.T) {
+	// Two entitlements with identical expiry — adapter breaks ties by
+	// alphabetic name so the chosen Plan is stable across runs.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(30 * 24 * time.Hour)
+	body := `{
+		"subscriber": {
+			"entitlements": {
+				"alpha": {"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"alpha_sku"},
+				"beta":  {"expires_date":"` + expires.Format(time.RFC3339) + `","product_identifier":"beta_sku"}
+			},
+			"subscriptions": {}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatNow(fixedNow(now)),
+	)
+	for i := 0; i < 10; i++ {
+		claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+		if err != nil {
+			t.Fatalf("GetSubscription error: %v", err)
+		}
+		if claim.Plan != "alpha" {
+			t.Fatalf("Plan = %q, want alpha (iteration %d)", claim.Plan, i)
+		}
+	}
+}
+
+func TestRevenueCat_MalformedJSON_ReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json {{`))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k", subscription.WithRevenueCatBaseURL(srv.URL))
+	claim, err := rc.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim on decode error, got %+v", claim)
+	}
+	if !strings.Contains(err.Error(), "revenuecat") {
+		t.Errorf("error = %v, want it to be namespaced revenuecat:", err)
+	}
+}
+
+// recordingTransport satisfies http.RoundTripper and captures the last
+// request observed, so we can assert that WithRevenueCatHTTPClient is
+// actually wired through to the request path.
+type recordingTransport struct {
+	last *http.Request
+	body string
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.last = req
+	body := t.body
+	if body == "" {
+		body = `{"subscriber":{"entitlements":{},"subscriptions":{}}}`
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func TestRevenueCat_WithHTTPClient_UsesProvidedClient(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{}
+	client := &http.Client{Transport: tr}
+
+	rc := subscription.NewRevenueCat(
+		"test-key",
+		subscription.WithRevenueCatBaseURL("https://api.example.com/v1"),
+		subscription.WithRevenueCatHTTPClient(client),
+	)
+	if _, err := rc.GetSubscription(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+
+	if tr.last == nil {
+		t.Fatal("custom transport was not used")
+	}
+	if got := tr.last.URL.String(); got != "https://api.example.com/v1/subscribers/agent-1" {
+		t.Errorf("request URL = %q, want https://api.example.com/v1/subscribers/agent-1", got)
+	}
+	if got := tr.last.Header.Get("Authorization"); got != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want Bearer test-key", got)
+	}
+}
+
+func TestRevenueCat_WithHTTPClient_NilNoOp(t *testing.T) {
+	// Passing nil to the option must not clobber the default client.
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"subscriber":{"entitlements":{},"subscriptions":{}}}`))
+	}))
+	defer srv.Close()
+
+	rc := subscription.NewRevenueCat("k",
+		subscription.WithRevenueCatBaseURL(srv.URL),
+		subscription.WithRevenueCatHTTPClient(nil),
+	)
+	if _, err := rc.GetSubscription(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+}
+
+func TestRevenueCat_AgentIDIsPathEscaped(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{}
+	client := &http.Client{Transport: tr}
+	rc := subscription.NewRevenueCat(
+		"k",
+		subscription.WithRevenueCatBaseURL("https://api.example.com/v1"),
+		subscription.WithRevenueCatHTTPClient(client),
+	)
+	// agent IDs containing slashes or spaces must not silently traverse
+	// path segments or break URL parsing.
+	if _, err := rc.GetSubscription(context.Background(), "weird/agent id", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if tr.last == nil {
+		t.Fatal("transport was not used")
+	}
+	want := "https://api.example.com/v1/subscribers/weird%2Fagent%20id"
+	if got := tr.last.URL.String(); got != want {
+		t.Errorf("URL = %q, want %q", got, want)
 	}
 }

--- a/pkg/auth/infrastructure/subscription/stripe.go
+++ b/pkg/auth/infrastructure/subscription/stripe.go
@@ -54,6 +54,17 @@ func WithStripeAgentMetadataKey(k string) StripeOption {
 	}
 }
 
+// WithStripeNow overrides the time source used to decide whether a
+// canceled subscription's paid period has actually lapsed. Tests inject
+// a fixed clock; production uses time.Now.
+func WithStripeNow(now func() time.Time) StripeOption {
+	return func(s *Stripe) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
 // Stripe resolves SubscriptionClaim values from the Stripe API by searching
 // customers on a configurable metadata field. It implements
 // application.SubscriptionService.
@@ -62,6 +73,7 @@ type Stripe struct {
 	baseURL          string
 	client           *http.Client
 	agentMetadataKey string
+	now              func() time.Time
 }
 
 // NewStripe returns a Stripe adapter authenticated with apiKey (a Stripe
@@ -73,6 +85,7 @@ func NewStripe(apiKey string, opts ...StripeOption) *Stripe {
 		baseURL:          stripeDefaultBaseURL,
 		client:           &http.Client{Timeout: 5 * time.Second},
 		agentMetadataKey: stripeDefaultMetadataKey,
+		now:              time.Now,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -150,9 +163,9 @@ func (s *Stripe) GetSubscription(ctx context.Context, agentID, accountID string)
 		return nil, errors.New("stripe: agentID must not be empty")
 	}
 
-	// Stripe search syntax: metadata['key']:'value'. Single quotes inside
-	// agentID are escaped per Stripe's docs by doubling — same convention
-	// SQL uses. Limits the blast radius of a malformed agent ID.
+	// Stripe search syntax: metadata['key']:'value'. Apostrophes inside
+	// agentID are backslash-escaped per Stripe's Search API grammar so a
+	// malformed or hostile agent ID can't break out of the quoted clause.
 	query := fmt.Sprintf("metadata['%s']:'%s'", s.agentMetadataKey, strings.ReplaceAll(agentID, "'", `\'`))
 	endpoint := fmt.Sprintf("%s/customers/search?query=%s&expand[]=data.subscriptions", s.baseURL, url.QueryEscape(query))
 
@@ -190,30 +203,52 @@ func (s *Stripe) GetSubscription(ctx context.Context, agentID, accountID string)
 // over other statuses; among ties, latest current_period_end wins;
 // further ties broken by subscription ID for stable output.
 func (s *Stripe) toClaim(search stripeCustomerSearch) *auth.SubscriptionClaim {
-	var best *stripeSubscription
+	var (
+		best        *stripeSubscription
+		bestCust    string
+		matchCount  int
+	)
 	for i := range search.Data {
 		for j := range search.Data[i].Subscriptions.Data {
 			cand := &search.Data[i].Subscriptions.Data[j]
 			if betterSubscription(best, cand) {
 				best = cand
+				bestCust = search.Data[i].ID
 			}
 		}
+		matchCount++
 	}
 	if best == nil {
 		return nil
 	}
 
+	status := stripeStatusToClaim(best.Status)
+	expiresAt := time.Time{}
+	if best.CurrentPeriodEnd > 0 {
+		expiresAt = time.Unix(best.CurrentPeriodEnd, 0).UTC()
+	}
+	// Stripe transitions to "canceled" the moment the merchant or user
+	// cancels, even when the customer has paid through current_period_end
+	// and is still entitled. Treat those as Active (with a cancelled
+	// metadata flag) so consumers don't revoke access early — same shape
+	// as cancel_at_period_end on a still-active subscription.
+	cancelledStillEntitled := status == auth.SubscriptionStatusCancelled &&
+		!expiresAt.IsZero() && expiresAt.After(s.now())
+	if cancelledStillEntitled {
+		status = auth.SubscriptionStatusActive
+	}
+
 	claim := &auth.SubscriptionClaim{
-		Status:   stripeStatusToClaim(best.Status),
+		Status:   status,
 		Provider: stripeProvider,
 		Plan:     subscriptionPlan(best),
 	}
-	if best.CurrentPeriodEnd > 0 {
-		claim.ExpiresAt = time.Unix(best.CurrentPeriodEnd, 0).UTC()
+	if !expiresAt.IsZero() {
+		claim.ExpiresAt = expiresAt
 	}
-	if best.CancelAtPeriodEnd {
-		// Surface the cancel-at-period-end flag for consumers that want
-		// to render renewal-status UI; the headline Status remains
+	if best.CancelAtPeriodEnd || cancelledStillEntitled {
+		// Surface the cancellation intent for consumers that want to
+		// render renewal-status UI; the headline Status remains
 		// active/trialing until the period actually lapses.
 		if claim.Metadata == nil {
 			claim.Metadata = map[string]any{}
@@ -225,6 +260,21 @@ func (s *Stripe) toClaim(search stripeCustomerSearch) *auth.SubscriptionClaim {
 			claim.Metadata = map[string]any{}
 		}
 		claim.Metadata["subscription_id"] = best.ID
+	}
+	if bestCust != "" {
+		if claim.Metadata == nil {
+			claim.Metadata = map[string]any{}
+		}
+		claim.Metadata["customer_id"] = bestCust
+	}
+	if matchCount > 1 {
+		// Multiple customers with the same metadata key indicate a
+		// data-quality issue (split-brain billing setup, migration
+		// artifact). Surface it so consumers can detect and fix.
+		if claim.Metadata == nil {
+			claim.Metadata = map[string]any{}
+		}
+		claim.Metadata["customer_match_count"] = matchCount
 	}
 	return claim
 }

--- a/pkg/auth/infrastructure/subscription/stripe.go
+++ b/pkg/auth/infrastructure/subscription/stripe.go
@@ -1,0 +1,277 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+)
+
+const (
+	stripeDefaultBaseURL     = "https://api.stripe.com/v1"
+	stripeDefaultMetadataKey = "agent_id"
+	stripeProvider           = "stripe"
+)
+
+// StripeOption configures a Stripe adapter.
+type StripeOption func(*Stripe)
+
+// WithStripeBaseURL overrides the API base URL. The test seam.
+func WithStripeBaseURL(u string) StripeOption {
+	return func(s *Stripe) {
+		if u != "" {
+			s.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithStripeHTTPClient overrides the HTTP client. Default is &http.Client
+// {Timeout: 5 * time.Second}; production deployments can plumb a shared
+// client with retries or instrumentation.
+func WithStripeHTTPClient(c *http.Client) StripeOption {
+	return func(s *Stripe) {
+		if c != nil {
+			s.client = c
+		}
+	}
+}
+
+// WithStripeAgentMetadataKey overrides the customer-metadata key the
+// adapter searches on. The default is "agent_id"; existing Stripe
+// installations may already store the link under a different key.
+func WithStripeAgentMetadataKey(k string) StripeOption {
+	return func(s *Stripe) {
+		if k != "" {
+			s.agentMetadataKey = k
+		}
+	}
+}
+
+// Stripe resolves SubscriptionClaim values from the Stripe API by searching
+// customers on a configurable metadata field. It implements
+// application.SubscriptionService.
+type Stripe struct {
+	apiKey           string
+	baseURL          string
+	client           *http.Client
+	agentMetadataKey string
+}
+
+// NewStripe returns a Stripe adapter authenticated with apiKey (a Stripe
+// secret key, "sk_..."). Construction with an empty key is permitted but
+// every call returns an error until the key is set.
+func NewStripe(apiKey string, opts ...StripeOption) *Stripe {
+	s := &Stripe{
+		apiKey:           apiKey,
+		baseURL:          stripeDefaultBaseURL,
+		client:           &http.Client{Timeout: 5 * time.Second},
+		agentMetadataKey: stripeDefaultMetadataKey,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// stripeCustomerSearch is the trimmed shape of GET /v1/customers/search
+// with `expand[]=data.subscriptions` so each customer carries its
+// subscription list inline. Only fields the adapter consumes are decoded.
+type stripeCustomerSearch struct {
+	Data []stripeCustomer `json:"data"`
+}
+
+type stripeCustomer struct {
+	ID            string `json:"id"`
+	Subscriptions struct {
+		Data []stripeSubscription `json:"data"`
+	} `json:"subscriptions"`
+}
+
+type stripeSubscription struct {
+	ID                string                  `json:"id"`
+	Status            string                  `json:"status"`
+	CurrentPeriodEnd  int64                   `json:"current_period_end"`
+	CancelAtPeriodEnd bool                    `json:"cancel_at_period_end"`
+	Items             stripeSubscriptionItems `json:"items"`
+}
+
+type stripeSubscriptionItems struct {
+	Data []stripeSubscriptionItem `json:"data"`
+}
+
+type stripeSubscriptionItem struct {
+	Price stripePrice `json:"price"`
+}
+
+type stripePrice struct {
+	LookupKey string `json:"lookup_key"`
+	Nickname  string `json:"nickname"`
+	Product   string `json:"product"`
+}
+
+// stripeStatusToClaim normalizes Stripe's subscription.status values into
+// auth.SubscriptionStatus. Statuses that map to no paid access (incomplete,
+// incomplete_expired, unpaid, paused) collapse to Inactive.
+func stripeStatusToClaim(status string) auth.SubscriptionStatus {
+	switch status {
+	case "active":
+		return auth.SubscriptionStatusActive
+	case "trialing":
+		return auth.SubscriptionStatusTrialing
+	case "past_due":
+		return auth.SubscriptionStatusPastDue
+	case "canceled":
+		return auth.SubscriptionStatusCancelled
+	default:
+		return auth.SubscriptionStatusInactive
+	}
+}
+
+// GetSubscription queries Stripe for the subscription tied to agentID via
+// the configured customer-metadata key. accountID is unused — Stripe is
+// keyed on a single customer per agent in this adapter; consumers needing
+// per-account billing should compose a different adapter or fork this one.
+// Returns (nil, nil) when no customer matches or when the customer has no
+// subscriptions; returns an error for transport failures, non-2xx responses
+// other than 404, and decode failures.
+func (s *Stripe) GetSubscription(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
+	_ = accountID
+	if s.apiKey == "" {
+		return nil, errors.New("stripe: missing API key")
+	}
+	if agentID == "" {
+		return nil, errors.New("stripe: agentID must not be empty")
+	}
+
+	// Stripe search syntax: metadata['key']:'value'. Single quotes inside
+	// agentID are escaped per Stripe's docs by doubling — same convention
+	// SQL uses. Limits the blast radius of a malformed agent ID.
+	query := fmt.Sprintf("metadata['%s']:'%s'", s.agentMetadataKey, strings.ReplaceAll(agentID, "'", `\'`))
+	endpoint := fmt.Sprintf("%s/customers/search?query=%s&expand[]=data.subscriptions", s.baseURL, url.QueryEscape(query))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("stripe: build request: %w", err)
+	}
+	req.SetBasicAuth(s.apiKey, "")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("stripe: http call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("stripe: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded stripeCustomerSearch
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("stripe: decode response: %w", err)
+	}
+
+	return s.toClaim(decoded), nil
+}
+
+// toClaim picks the best subscription across all matched customers and
+// maps it to a SubscriptionClaim. Selection order: prefer active/trialing
+// over other statuses; among ties, latest current_period_end wins;
+// further ties broken by subscription ID for stable output.
+func (s *Stripe) toClaim(search stripeCustomerSearch) *auth.SubscriptionClaim {
+	var best *stripeSubscription
+	for i := range search.Data {
+		for j := range search.Data[i].Subscriptions.Data {
+			cand := &search.Data[i].Subscriptions.Data[j]
+			if betterSubscription(best, cand) {
+				best = cand
+			}
+		}
+	}
+	if best == nil {
+		return nil
+	}
+
+	claim := &auth.SubscriptionClaim{
+		Status:   stripeStatusToClaim(best.Status),
+		Provider: stripeProvider,
+		Plan:     subscriptionPlan(best),
+	}
+	if best.CurrentPeriodEnd > 0 {
+		claim.ExpiresAt = time.Unix(best.CurrentPeriodEnd, 0).UTC()
+	}
+	if best.CancelAtPeriodEnd {
+		// Surface the cancel-at-period-end flag for consumers that want
+		// to render renewal-status UI; the headline Status remains
+		// active/trialing until the period actually lapses.
+		if claim.Metadata == nil {
+			claim.Metadata = map[string]any{}
+		}
+		claim.Metadata["cancel_at_period_end"] = true
+	}
+	if best.ID != "" {
+		if claim.Metadata == nil {
+			claim.Metadata = map[string]any{}
+		}
+		claim.Metadata["subscription_id"] = best.ID
+	}
+	return claim
+}
+
+// betterSubscription returns true when cand should replace best. Active
+// and trialing rank above any other status; within a rank, latest period
+// end wins; within that, subscription ID breaks ties for stable output
+// regardless of map iteration order in the response.
+func betterSubscription(best, cand *stripeSubscription) bool {
+	if best == nil {
+		return true
+	}
+	bestRank := stripeRank(best.Status)
+	candRank := stripeRank(cand.Status)
+	if candRank != bestRank {
+		return candRank > bestRank
+	}
+	if cand.CurrentPeriodEnd != best.CurrentPeriodEnd {
+		return cand.CurrentPeriodEnd > best.CurrentPeriodEnd
+	}
+	return cand.ID < best.ID
+}
+
+func stripeRank(status string) int {
+	switch status {
+	case "active", "trialing":
+		return 3
+	case "past_due":
+		return 2
+	case "canceled":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func subscriptionPlan(sub *stripeSubscription) string {
+	if sub == nil || len(sub.Items.Data) == 0 {
+		return ""
+	}
+	p := sub.Items.Data[0].Price
+	switch {
+	case p.LookupKey != "":
+		return p.LookupKey
+	case p.Nickname != "":
+		return p.Nickname
+	default:
+		return p.Product
+	}
+}

--- a/pkg/auth/infrastructure/subscription/stripe_test.go
+++ b/pkg/auth/infrastructure/subscription/stripe_test.go
@@ -1,0 +1,492 @@
+package subscription_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/subscription"
+)
+
+var _ application.SubscriptionService = (*subscription.Stripe)(nil)
+
+// stripeFixture builds a Stripe customer-search response body with the
+// given subscriptions. Only fields the adapter consumes are populated.
+func stripeFixture(subs ...string) string {
+	if len(subs) == 0 {
+		return `{"data":[]}`
+	}
+	return `{"data":[{"id":"cus_1","subscriptions":{"data":[` + strings.Join(subs, ",") + `]}}]}`
+}
+
+func stripeSub(id, status string, periodEnd int64, lookupKey string, cancelAtPeriodEnd bool) string {
+	cape := "false"
+	if cancelAtPeriodEnd {
+		cape = "true"
+	}
+	return `{"id":"` + id + `","status":"` + status + `","current_period_end":` + strconv.FormatInt(periodEnd, 10) + `,"cancel_at_period_end":` + cape + `,"items":{"data":[{"price":{"lookup_key":"` + lookupKey + `"}}]}}`
+}
+
+func TestStripe_NoCustomerMatch_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+}
+
+func TestStripe_CustomerWithNoSubscriptions_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"cus_1","subscriptions":{"data":[]}}]}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+}
+
+func TestStripe_ActiveSubscription(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).Unix()
+	body := stripeFixture(stripeSub("sub_1", "active", periodEnd, "pro_monthly", false))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify HTTP basic auth uses the API key.
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Basic ") {
+			t.Errorf("Authorization scheme = %q, want Basic", authHeader)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(authHeader, "Basic "))
+		if err != nil {
+			t.Fatalf("could not decode basic auth: %v", err)
+		}
+		if string(decoded) != "sk_test:" {
+			t.Errorf("basic auth = %q, want sk_test:", decoded)
+		}
+		// Verify the search query and expand parameters.
+		q := r.URL.Query().Get("query")
+		if !strings.Contains(q, "metadata['agent_id']:'agent-1'") {
+			t.Errorf("query = %q, want metadata['agent_id']:'agent-1'", q)
+		}
+		if got := r.URL.Query()["expand[]"]; len(got) != 1 || got[0] != "data.subscriptions" {
+			t.Errorf("expand = %v, want [data.subscriptions]", got)
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected non-nil claim")
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusActive)
+	}
+	if claim.Plan != "pro_monthly" {
+		t.Errorf("Plan = %q, want %q", claim.Plan, "pro_monthly")
+	}
+	if claim.Provider != "stripe" {
+		t.Errorf("Provider = %q, want %q", claim.Provider, "stripe")
+	}
+	if !claim.ExpiresAt.Equal(time.Unix(periodEnd, 0).UTC()) {
+		t.Errorf("ExpiresAt = %v, want %v", claim.ExpiresAt, time.Unix(periodEnd, 0).UTC())
+	}
+	if got := claim.Metadata["subscription_id"]; got != "sub_1" {
+		t.Errorf("Metadata[subscription_id] = %v, want sub_1", got)
+	}
+	if _, ok := claim.Metadata["cancel_at_period_end"]; ok {
+		t.Errorf("cancel_at_period_end should be absent when false, got %v", claim.Metadata["cancel_at_period_end"])
+	}
+}
+
+func TestStripe_TrialingSubscription(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(7 * 24 * time.Hour).Unix()
+	body := stripeFixture(stripeSub("sub_1", "trialing", periodEnd, "trial", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusTrialing {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusTrialing)
+	}
+}
+
+func TestStripe_PastDueSubscription(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(7 * 24 * time.Hour).Unix()
+	body := stripeFixture(stripeSub("sub_1", "past_due", periodEnd, "pro", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusPastDue {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusPastDue)
+	}
+}
+
+func TestStripe_CanceledSubscription(t *testing.T) {
+	t.Parallel()
+
+	body := stripeFixture(stripeSub("sub_1", "canceled", 0, "pro", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusCancelled {
+		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusCancelled)
+	}
+}
+
+func TestStripe_IncompleteOrPaused_MapToInactive(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{"incomplete", "incomplete_expired", "unpaid", "paused"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			body := stripeFixture(stripeSub("sub_1", status, 0, "pro", false))
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(body))
+			}))
+			defer srv.Close()
+			s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+			claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+			if err != nil {
+				t.Fatalf("GetSubscription error: %v", err)
+			}
+			if claim.Status != auth.SubscriptionStatusInactive {
+				t.Errorf("Status = %q, want %q for stripe status %q", claim.Status, auth.SubscriptionStatusInactive, status)
+			}
+		})
+	}
+}
+
+func TestStripe_PrefersActiveOverCancelled(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(30 * 24 * time.Hour).Unix()
+	body := stripeFixture(
+		stripeSub("sub_old", "canceled", 0, "old_plan", false),
+		stripeSub("sub_new", "active", periodEnd, "new_plan", false),
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want active (preferred over canceled)", claim.Status)
+	}
+	if claim.Plan != "new_plan" {
+		t.Errorf("Plan = %q, want new_plan", claim.Plan)
+	}
+}
+
+func TestStripe_TwoActive_PicksLaterPeriodEnd(t *testing.T) {
+	t.Parallel()
+
+	earlier := time.Now().Add(7 * 24 * time.Hour).Unix()
+	later := time.Now().Add(60 * 24 * time.Hour).Unix()
+	body := stripeFixture(
+		stripeSub("sub_a", "active", earlier, "early_plan", false),
+		stripeSub("sub_b", "active", later, "late_plan", false),
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "late_plan" {
+		t.Errorf("Plan = %q, want late_plan (later period_end)", claim.Plan)
+	}
+}
+
+func TestStripe_CancelAtPeriodEnd_StaysActive_FlagsMetadata(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(7 * 24 * time.Hour).Unix()
+	body := stripeFixture(stripeSub("sub_1", "active", periodEnd, "pro", true))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want active until period actually ends", claim.Status)
+	}
+	if got := claim.Metadata["cancel_at_period_end"]; got != true {
+		t.Errorf("cancel_at_period_end metadata = %v, want true", got)
+	}
+}
+
+func TestStripe_PlanFallback_NicknameThenProduct(t *testing.T) {
+	t.Parallel()
+
+	body := `{"data":[{"id":"cus_1","subscriptions":{"data":[{"id":"sub_1","status":"active","current_period_end":0,"items":{"data":[{"price":{"nickname":"Pro Plan","product":"prod_xyz"}}]}}]}}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "Pro Plan" {
+		t.Errorf("Plan = %q, want Pro Plan (nickname fallback)", claim.Plan)
+	}
+
+	body = `{"data":[{"id":"cus_1","subscriptions":{"data":[{"id":"sub_1","status":"active","items":{"data":[{"price":{"product":"prod_xyz"}}]}}]}}]}`
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv2.Close()
+	s2 := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv2.URL))
+	claim2, err := s2.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim2.Plan != "prod_xyz" {
+		t.Errorf("Plan = %q, want prod_xyz (product fallback)", claim2.Plan)
+	}
+}
+
+func TestStripe_CustomMetadataKey(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("query")
+		if !strings.Contains(q, "metadata['pericarp_agent']:'agent-1'") {
+			t.Errorf("query = %q, want metadata['pericarp_agent']:'agent-1'", q)
+		}
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test",
+		subscription.WithStripeBaseURL(srv.URL),
+		subscription.WithStripeAgentMetadataKey("pericarp_agent"),
+	)
+	if _, err := s.GetSubscription(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+}
+
+func TestStripe_AgentIDQuoteEscaped(t *testing.T) {
+	// A defensive escape against an apostrophe in the agent ID
+	// breaking out of the search query string.
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, err := url.QueryUnescape(r.URL.Query().Get("query"))
+		if err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		if !strings.Contains(q, `metadata['agent_id']:'agent\'1'`) {
+			t.Errorf("query = %q, want backslash-escaped apostrophe", q)
+		}
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	if _, err := s.GetSubscription(context.Background(), "agent'1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+}
+
+func TestStripe_NotFound_ReturnsNilNoError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim for 404, got %+v", claim)
+	}
+}
+
+func TestStripe_NonOKStatus_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid query"}}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	_, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error = %v, want it to mention 400", err)
+	}
+}
+
+func TestStripe_MalformedJSON_ReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json {{`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+	if !strings.Contains(err.Error(), "stripe") {
+		t.Errorf("error = %v, want it namespaced stripe:", err)
+	}
+}
+
+func TestStripe_MissingAPIKey_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := subscription.NewStripe("")
+	if _, err := s.GetSubscription(context.Background(), "agent-1", ""); err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestStripe_EmptyAgentID_Errors(t *testing.T) {
+	t.Parallel()
+
+	s := subscription.NewStripe("sk_test")
+	if _, err := s.GetSubscription(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error for empty agent ID")
+	}
+}
+
+func TestStripe_CancelledContext_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.GetSubscription(ctx, "agent-1", ""); err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestStripe_WithHTTPClient_UsesProvidedClient(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{body: `{"data":[]}`}
+	client := &http.Client{Transport: tr}
+
+	s := subscription.NewStripe("sk_test",
+		subscription.WithStripeBaseURL("https://api.example.com/v1"),
+		subscription.WithStripeHTTPClient(client),
+	)
+	if _, err := s.GetSubscription(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if tr.last == nil {
+		t.Fatal("custom transport not used")
+	}
+	if !strings.HasPrefix(tr.last.URL.String(), "https://api.example.com/v1/customers/search") {
+		t.Errorf("URL = %q, want prefix https://api.example.com/v1/customers/search", tr.last.URL.String())
+	}
+}
+
+func TestStripe_WithHTTPClient_NilNoOp(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test",
+		subscription.WithStripeBaseURL(srv.URL),
+		subscription.WithStripeHTTPClient(nil),
+	)
+	if _, err := s.GetSubscription(context.Background(), "agent-1", ""); err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+}
+

--- a/pkg/auth/infrastructure/subscription/stripe_test.go
+++ b/pkg/auth/infrastructure/subscription/stripe_test.go
@@ -473,6 +473,191 @@ func TestStripe_WithHTTPClient_UsesProvidedClient(t *testing.T) {
 	}
 }
 
+func TestStripe_CanceledButStillInPaidWindow_StaysActive(t *testing.T) {
+	// Stripe flips status to "canceled" the moment the merchant cancels
+	// even though current_period_end is still in the future and the
+	// customer is entitled to access through that date. Adapter must
+	// keep IsActive() = true and surface the cancellation in metadata.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	periodEnd := now.Add(7 * 24 * time.Hour).Unix()
+	body := stripeFixture(stripeSub("sub_1", "canceled", periodEnd, "pro", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test",
+		subscription.WithStripeBaseURL(srv.URL),
+		subscription.WithStripeNow(func() time.Time { return now }),
+	)
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want Active while still in paid window", claim.Status)
+	}
+	if !claim.IsActive() {
+		t.Error("IsActive() = false, want true")
+	}
+	if got := claim.Metadata["cancel_at_period_end"]; got != true {
+		t.Errorf("cancel_at_period_end metadata = %v, want true", got)
+	}
+}
+
+func TestStripe_CanceledExpired_StaysCancelled(t *testing.T) {
+	// Same status string, but the paid window has lapsed — adapter must
+	// fall through to Cancelled.
+	t.Parallel()
+
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-7 * 24 * time.Hour).Unix()
+	body := stripeFixture(stripeSub("sub_1", "canceled", expired, "pro", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test",
+		subscription.WithStripeBaseURL(srv.URL),
+		subscription.WithStripeNow(func() time.Time { return now }),
+	)
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusCancelled {
+		t.Errorf("Status = %q, want Cancelled after period lapsed", claim.Status)
+	}
+}
+
+func TestStripe_CanceledZeroPeriodEnd_StaysCancelled(t *testing.T) {
+	// current_period_end == 0 (no expiry stamped) collapses to Cancelled
+	// — there's no future window to honor. ExpiresAt should also stay
+	// zero so IsActive doesn't accidentally flip on a missing expiry.
+	t.Parallel()
+
+	body := stripeFixture(stripeSub("sub_1", "canceled", 0, "pro", false))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Status != auth.SubscriptionStatusCancelled {
+		t.Errorf("Status = %q, want Cancelled", claim.Status)
+	}
+	if !claim.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt = %v, want zero when current_period_end == 0", claim.ExpiresAt)
+	}
+}
+
+func TestStripe_TrialingBeatsPastDue(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(7 * 24 * time.Hour).Unix()
+	body := stripeFixture(
+		stripeSub("sub_pd", "past_due", periodEnd, "pd_plan", false),
+		stripeSub("sub_tr", "trialing", periodEnd, "tr_plan", false),
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "tr_plan" {
+		t.Errorf("Plan = %q, want tr_plan (trialing beats past_due)", claim.Plan)
+	}
+}
+
+func TestStripe_TieBreakBySubscriptionID(t *testing.T) {
+	t.Parallel()
+
+	periodEnd := time.Now().Add(30 * 24 * time.Hour).Unix()
+	body := stripeFixture(
+		stripeSub("sub_b", "active", periodEnd, "b_plan", false),
+		stripeSub("sub_a", "active", periodEnd, "a_plan", false),
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	for i := 0; i < 5; i++ {
+		claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+		if err != nil {
+			t.Fatalf("GetSubscription error: %v", err)
+		}
+		if claim.Plan != "a_plan" {
+			t.Fatalf("Plan = %q, want a_plan (lex-first ID), iteration %d", claim.Plan, i)
+		}
+	}
+}
+
+func TestStripe_MultipleCustomers_PicksBestAcrossAll(t *testing.T) {
+	// Outer loop over search.Data must be exercised. The active
+	// subscription is on cus_2; cus_1 only has a canceled one. The
+	// adapter walks both and picks the active.
+	t.Parallel()
+
+	periodEnd := time.Now().Add(30 * 24 * time.Hour).Unix()
+	body := `{"data":[
+		{"id":"cus_1","subscriptions":{"data":[` + stripeSub("sub_old", "canceled", 0, "old_plan", false) + `]}},
+		{"id":"cus_2","subscriptions":{"data":[` + stripeSub("sub_new", "active", periodEnd, "new_plan", false) + `]}}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "new_plan" {
+		t.Errorf("Plan = %q, want new_plan (active wins across customers)", claim.Plan)
+	}
+	if got := claim.Metadata["customer_id"]; got != "cus_2" {
+		t.Errorf("Metadata[customer_id] = %v, want cus_2", got)
+	}
+	if got := claim.Metadata["customer_match_count"]; got != 2 {
+		t.Errorf("Metadata[customer_match_count] = %v, want 2 (split-brain marker)", got)
+	}
+}
+
+func TestStripe_EmptyItems_PlanIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	body := `{"data":[{"id":"cus_1","subscriptions":{"data":[{"id":"sub_1","status":"active","current_period_end":0,"items":{"data":[]}}]}}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := subscription.NewStripe("sk_test", subscription.WithStripeBaseURL(srv.URL))
+	claim, err := s.GetSubscription(context.Background(), "agent-1", "")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim.Plan != "" {
+		t.Errorf("Plan = %q, want empty for subscription with no items", claim.Plan)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want Active", claim.Status)
+	}
+}
+
 func TestStripe_WithHTTPClient_NilNoOp(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/subscription.go
+++ b/pkg/auth/subscription.go
@@ -1,0 +1,52 @@
+package auth
+
+import "time"
+
+// SubscriptionStatus enumerates the lifecycle states a subscription can be in.
+// Provider-specific states are normalized into one of these values so consumer
+// services can gate access uniformly regardless of billing backend.
+type SubscriptionStatus string
+
+const (
+	// SubscriptionStatusActive — paid and current. Grant paid-tier access.
+	SubscriptionStatusActive SubscriptionStatus = "active"
+	// SubscriptionStatusTrialing — in a trial period. Grant paid-tier access.
+	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
+	// SubscriptionStatusPastDue — payment failed but provider has not yet
+	// cancelled. Treated as inactive by IsActive; consumers may choose a
+	// grace-period policy on top.
+	SubscriptionStatusPastDue SubscriptionStatus = "past_due"
+	// SubscriptionStatusCancelled — explicitly cancelled (no longer renewing).
+	SubscriptionStatusCancelled SubscriptionStatus = "cancelled"
+	// SubscriptionStatusInactive — no active subscription found.
+	SubscriptionStatusInactive SubscriptionStatus = "inactive"
+)
+
+// SubscriptionClaim is the normalized subscription snapshot embedded in an
+// identity token at issuance time. Consumers read it off the validated token
+// instead of looking up billing state per request.
+//
+// Metadata carries provider-specific fields (e.g., Stripe metadata,
+// RevenueCat entitlement keys). It is preserved verbatim so consumers can
+// reach into provider-native data when the normalized fields are not enough.
+type SubscriptionClaim struct {
+	Status    SubscriptionStatus `json:"status"`
+	Plan      string             `json:"plan,omitempty"`
+	Provider  string             `json:"provider,omitempty"`
+	ExpiresAt time.Time          `json:"expires_at,omitzero"`
+	Metadata  map[string]any     `json:"metadata,omitempty"`
+}
+
+// IsActive reports whether the subscription should grant paid-tier access.
+// A nil claim is inactive by definition (no subscription was looked up or
+// the provider returned no record for the agent).
+func (s *SubscriptionClaim) IsActive() bool {
+	if s == nil {
+		return false
+	}
+	switch s.Status {
+	case SubscriptionStatusActive, SubscriptionStatusTrialing:
+		return true
+	}
+	return false
+}

--- a/pkg/auth/subscription.go
+++ b/pkg/auth/subscription.go
@@ -2,46 +2,66 @@ package auth
 
 import "time"
 
-// SubscriptionStatus enumerates the lifecycle states a subscription can be in.
-// Provider-specific states are normalized into one of these values so consumer
-// services can gate access uniformly regardless of billing backend.
+// SubscriptionStatus enumerates the lifecycle states a subscription can be
+// in. Provider-specific states are normalized into one of these values so
+// consumers can gate access uniformly regardless of billing backend.
 type SubscriptionStatus string
 
 const (
-	// SubscriptionStatusActive — paid and current. Grant paid-tier access.
-	SubscriptionStatusActive SubscriptionStatus = "active"
-	// SubscriptionStatusTrialing — in a trial period. Grant paid-tier access.
+	SubscriptionStatusActive   SubscriptionStatus = "active"
 	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
-	// SubscriptionStatusPastDue — payment failed but provider has not yet
-	// cancelled. Treated as inactive by IsActive; consumers may choose a
-	// grace-period policy on top.
-	SubscriptionStatusPastDue SubscriptionStatus = "past_due"
-	// SubscriptionStatusCancelled — explicitly cancelled (no longer renewing).
+	// PastDue is split out from Cancelled because billing providers commonly
+	// flag a failed payment without ending the subscription. Treated as
+	// inactive by IsActive; consumers may layer a grace-period policy on top.
+	SubscriptionStatusPastDue   SubscriptionStatus = "past_due"
 	SubscriptionStatusCancelled SubscriptionStatus = "cancelled"
-	// SubscriptionStatusInactive — no active subscription found.
-	SubscriptionStatusInactive SubscriptionStatus = "inactive"
+	SubscriptionStatusInactive  SubscriptionStatus = "inactive"
 )
 
+// Valid reports whether s is one of the defined SubscriptionStatus
+// constants. Useful in adapter-side tests to catch provider-string drift
+// (e.g. "ACTIVE" vs "active") before a malformed status reaches token
+// issuance and silently downgrades a paying customer.
+func (s SubscriptionStatus) Valid() bool {
+	switch s {
+	case SubscriptionStatusActive,
+		SubscriptionStatusTrialing,
+		SubscriptionStatusPastDue,
+		SubscriptionStatusCancelled,
+		SubscriptionStatusInactive:
+		return true
+	}
+	return false
+}
+
 // SubscriptionClaim is the normalized subscription snapshot embedded in an
-// identity token at issuance time. Consumers read it off the validated token
-// instead of looking up billing state per request.
-//
-// Metadata carries provider-specific fields (e.g., Stripe metadata,
-// RevenueCat entitlement keys). It is preserved verbatim so consumers can
-// reach into provider-native data when the normalized fields are not enough.
+// identity token at issuance time. Consumers read it off the validated
+// token instead of looking up billing state per request. Metadata is the
+// open extension space for provider-specific fields (Stripe metadata,
+// RevenueCat entitlements); the four normalized fields above it are the
+// minimal common shape every consumer can rely on.
 type SubscriptionClaim struct {
-	Status    SubscriptionStatus `json:"status"`
-	Plan      string             `json:"plan,omitempty"`
-	Provider  string             `json:"provider,omitempty"`
-	ExpiresAt time.Time          `json:"expires_at,omitzero"`
-	Metadata  map[string]any     `json:"metadata,omitempty"`
+	Status   SubscriptionStatus `json:"status"`
+	Plan     string             `json:"plan,omitempty"`
+	Provider string             `json:"provider,omitempty"`
+	// ExpiresAt uses omitzero (Go 1.24+) because time.Time's zero value is
+	// not the JSON zero value — omitempty would emit "0001-01-01T00:00:00Z"
+	// for unset times instead of dropping the field.
+	ExpiresAt time.Time      `json:"expires_at,omitzero"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
 }
 
 // IsActive reports whether the subscription should grant paid-tier access.
-// A nil claim is inactive by definition (no subscription was looked up or
-// the provider returned no record for the agent).
+// Returns false for a nil receiver, for any non-active/trialing status, and
+// for an explicit ExpiresAt in the past — that last guard means a stale
+// snapshot held across an account-switch (which preserves the claim
+// verbatim) cannot grant access beyond the provider-attested expiry. A
+// zero ExpiresAt is treated as "no expiry expressed" and ignored.
 func (s *SubscriptionClaim) IsActive() bool {
 	if s == nil {
+		return false
+	}
+	if !s.ExpiresAt.IsZero() && time.Now().After(s.ExpiresAt) {
 		return false
 	}
 	switch s.Status {

--- a/pkg/auth/subscription_test.go
+++ b/pkg/auth/subscription_test.go
@@ -1,9 +1,15 @@
 package auth
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestSubscriptionClaim_IsActive(t *testing.T) {
 	t.Parallel()
+
+	future := time.Now().Add(24 * time.Hour)
+	past := time.Now().Add(-24 * time.Hour)
 
 	tests := []struct {
 		name   string
@@ -11,8 +17,12 @@ func TestSubscriptionClaim_IsActive(t *testing.T) {
 		active bool
 	}{
 		{name: "nil claim", claim: nil, active: false},
-		{name: "active", claim: &SubscriptionClaim{Status: SubscriptionStatusActive}, active: true},
-		{name: "trialing", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing}, active: true},
+		{name: "active no expiry", claim: &SubscriptionClaim{Status: SubscriptionStatusActive}, active: true},
+		{name: "active expires future", claim: &SubscriptionClaim{Status: SubscriptionStatusActive, ExpiresAt: future}, active: true},
+		{name: "active expires past", claim: &SubscriptionClaim{Status: SubscriptionStatusActive, ExpiresAt: past}, active: false},
+		{name: "trialing no expiry", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing}, active: true},
+		{name: "trialing expires future", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing, ExpiresAt: future}, active: true},
+		{name: "trialing expires past", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing, ExpiresAt: past}, active: false},
 		{name: "past_due", claim: &SubscriptionClaim{Status: SubscriptionStatusPastDue}, active: false},
 		{name: "cancelled", claim: &SubscriptionClaim{Status: SubscriptionStatusCancelled}, active: false},
 		{name: "inactive", claim: &SubscriptionClaim{Status: SubscriptionStatusInactive}, active: false},
@@ -25,6 +35,34 @@ func TestSubscriptionClaim_IsActive(t *testing.T) {
 			t.Parallel()
 			if got := tc.claim.IsActive(); got != tc.active {
 				t.Errorf("IsActive() = %v, want %v", got, tc.active)
+			}
+		})
+	}
+}
+
+func TestSubscriptionStatus_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status SubscriptionStatus
+		valid  bool
+	}{
+		{SubscriptionStatusActive, true},
+		{SubscriptionStatusTrialing, true},
+		{SubscriptionStatusPastDue, true},
+		{SubscriptionStatusCancelled, true},
+		{SubscriptionStatusInactive, true},
+		{"ACTIVE", false}, // wrong case
+		{"trial", false},  // truncated
+		{"", false},
+		{"frobnicated", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			t.Parallel()
+			if got := tc.status.Valid(); got != tc.valid {
+				t.Errorf("Valid(%q) = %v, want %v", tc.status, got, tc.valid)
 			}
 		})
 	}

--- a/pkg/auth/subscription_test.go
+++ b/pkg/auth/subscription_test.go
@@ -1,0 +1,31 @@
+package auth
+
+import "testing"
+
+func TestSubscriptionClaim_IsActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		claim  *SubscriptionClaim
+		active bool
+	}{
+		{name: "nil claim", claim: nil, active: false},
+		{name: "active", claim: &SubscriptionClaim{Status: SubscriptionStatusActive}, active: true},
+		{name: "trialing", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing}, active: true},
+		{name: "past_due", claim: &SubscriptionClaim{Status: SubscriptionStatusPastDue}, active: false},
+		{name: "cancelled", claim: &SubscriptionClaim{Status: SubscriptionStatusCancelled}, active: false},
+		{name: "inactive", claim: &SubscriptionClaim{Status: SubscriptionStatusInactive}, active: false},
+		{name: "unknown status", claim: &SubscriptionClaim{Status: "frobnicated"}, active: false},
+		{name: "empty status", claim: &SubscriptionClaim{}, active: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.claim.IsActive(); got != tc.active {
+				t.Errorf("IsActive() = %v, want %v", got, tc.active)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #24.

All four stories are landed on this branch with /pr-review feedback addressed on each:

## Story 1 — Core interface + JWT integration
- `auth.SubscriptionClaim` value type + `SubscriptionStatus` constants + `IsActive()` (consults `ExpiresAt` so a stale snapshot can't grant access past the provider-attested expiry); `SubscriptionStatus.Valid()` to catch provider-string drift.
- `application.SubscriptionService` interface; `WithSubscriptionService` functional option; `PericarpClaims.Subscription` field.
- `JWTService.IssueToken` gains a 5th `*auth.SubscriptionClaim` param. `ReissueToken` preserves the claim verbatim.
- `AuthenticationService.IssueIdentityToken` orchestrates the lookup. **Lookup failures are logged but do NOT block token issuance** — billing-provider outages must not break login.
- `RequireJWT` populates `auth.Identity.Subscription`; `RequireAuth` (session) leaves it nil.

## Story 2 — RevenueCat adapter (`pkg/auth/infrastructure/subscription/revenuecat.go`)
- `GET /v1/subscribers/{agent_id}` → `*auth.SubscriptionClaim`. Maps the latest-expiring entitlement; lifetime entitlements (null `expires_date`) win over time-bounded.
- Honors `unsubscribe_detected_at` (refunded lifetime → Inactive); `billing_issues_detected_at` (PastDue); `period_type=trial` (Trialing).
- Falls back to scanning all subscriptions when the matched-row keying misses (multi-SKU offerings, upgrades, promo grants).
- agentID `url.PathEscape`d.

## Story 3 — Stripe adapter (`pkg/auth/infrastructure/subscription/stripe.go`)
- `customers/search?query=metadata['agent_id']:'...'&expand[]=data.subscriptions` → `*auth.SubscriptionClaim`. Configurable metadata key via `WithStripeAgentMetadataKey`.
- `canceled` with future `current_period_end` keeps `IsActive()` true (paid through, just won't renew) — surfaced via `cancel_at_period_end` metadata flag. Once the period lapses it becomes Cancelled.
- Selection ranks active/trialing > past_due > canceled; ties on later period_end then subscription ID for stable output.
- Plan precedence: `lookup_key` → `nickname` → `product`.
- Metadata stamps `customer_id` and `customer_match_count` (split-brain billing setups become detectable).
- Apostrophes in agentID backslash-escaped per Stripe's Search API grammar.

## Story 4 — GORM adapter (`pkg/auth/infrastructure/subscription/gorm.go`)
- Default schema: `SubscriptionRecord` (agent_id, account_id, status, plan, provider, expires_at, updated_at).
- **Strict account scoping**: when accountID is non-empty, requires an exact (agent_id, account_id) match — no agent-only fallback — so a paid personal-account subscription cannot silently grant paid-tier access to a B2B/team account the same agent belongs to.
- Latest `updated_at` wins; ties break on `id DESC` for determinism.
- `WithGORMTable` overrides the table name; `WithGORMResolver` is the fully-custom-query escape hatch; `WithGORMProvider` stamps a fallback Provider when the row column is empty (row value wins when present).
- Validates returned `Status` against `SubscriptionStatus.Valid()` — a typo'd "ACTIVE" or schema drift surfaces as a loud error rather than a silent token claim.
- Returns `(nil, nil)` for ErrRecordNotFound; propagates real DB failures.

## Test plan
- [x] `make dev-test` (fmt + lint + race-enabled tests) — clean
- [x] 69 tests in `pkg/auth/infrastructure/subscription` covering happy paths, status mappings, selection precedence, fallback semantics, error propagation, options nil-safety, and provider-specific edge cases (RevenueCat lifetime revocation, Stripe canceled-but-paid-window, GORM cross-account leak guard)
- [x] Round-trip tests at `pkg/auth/infrastructure/jwt` confirm `Status`, `Plan`, `Provider`, `ExpiresAt`, `Metadata` all survive sign/validate
- [x] Middleware test confirms `auth.Identity.Subscription` is populated end-to-end via JWT and stays nil under session-only auth
- [ ] Manual validation in apollo against the GORM adapter once cut over (deferred to consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)