### PR TITLE
feat(auth): NetSuite OAuth 2.0 provider + docs and example wiring (epic #26)

### DIFF
--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -51,3 +51,16 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 - Bcrypt via `golang.org/x/crypto/bcrypt`, default cost configurable via `WithBcryptCost`. Algorithm stored on the row to allow future migration (e.g. argon2id)
 - Password support is opt-in via `WithPasswordCredentialRepository`; password methods return `ErrPasswordSupportNotConfigured` until wired
 - **Why:** Apollo and other downstream services need email/password sign-in without bolting their own auth lane on top. OAuth lane untouched; bcrypt blobs from legacy systems can be imported as-is via `ImportPasswordCredential`
+
+---
+
+### 2026-04-25: NetSuite OAuth 2.0 provider
+
+- Added `providers.NewNetSuite(NetSuiteConfig{...})` in `pkg/auth/infrastructure/providers/netsuite.go` — fifth shipping OAuth provider alongside Apple/GitHub/Google/Microsoft
+- Per-account hosts (auth → `<account>.app.netsuite.com`, token/revoke/userinfo → `<account>.suitetalk.api.netsuite.com`) are derived from `AccountID` with NetSuite's documented normalization (lowercase + `_` → `-`), mirroring how Microsoft templates `tenantID`. Sandbox `1234567_SB1` resolves to `1234567-sb1.app.netsuite.com` automatically
+- Each endpoint accepts an explicit override that **wins over the derived URL even when `AccountID` is set** — safety valve for sandboxes with non-standard hosts and any future NetSuite endpoint change. Override-only-when-AccountID-is-empty was explicitly called out as the trap to avoid
+- `ValidateIDToken` returns sentinel `ErrNetSuiteIDTokenNotSupported` because NetSuite's OAuth 2.0 doesn't reliably issue OIDC-conformant ID tokens; user info is fetched via `Exchange` (NetSuite's `userinfo` endpoint)
+- Default scope is `["rest_webservices"]` — required for the SuiteTalk REST userinfo endpoint, so `Exchange` works against a real tenant out of the box
+- Token endpoint surfaces OAuth 2.0 error bodies returned with HTTP 200 and rejects empty `access_token`; userinfo rejects empty `sub` — guards against silent partial-response failure modes that otherwise produce blank-identity sessions
+- Added `pkg/auth/PROVIDERS.md` provider catalog (first time the auth package has shipped a catalog doc) and `examples/authn/provider_catalog.go` with `BuildProviderRegistry()` as the copy-pasteable wiring template for downstream services
+- **Why:** Closes epic #26 — downstream services can register NetSuite the same way they register Google/Microsoft, picking up sandbox support and endpoint overrides without writing their own NetSuite adapter

--- a/examples/authn/main.go
+++ b/examples/authn/main.go
@@ -50,10 +50,7 @@ func RunAuthenticationFlow(ctx context.Context) (*FlowResult, error) {
 	fmt.Println("[2] RSAJWTService created")
 
 	// --- 3. Wire DefaultAuthenticationService ---
-	provider := NewMockOAuthProvider("mock-idp")
-	providers := application.OAuthProviderRegistry{
-		"mock-idp": provider,
-	}
+	providers := BuildProviderRegistry()
 	agents := NewMemoryAgentRepository()
 	credentials := NewMemoryCredentialRepository()
 	sessions := NewMemorySessionRepository()

--- a/examples/authn/main_test.go
+++ b/examples/authn/main_test.go
@@ -11,6 +11,23 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 )
 
+func TestProviderRegistry_RegistersExpectedProviders(t *testing.T) {
+	t.Parallel()
+
+	registry := BuildProviderRegistry()
+
+	for _, name := range []string{"mock-idp", "netsuite"} {
+		p, ok := registry[name]
+		if !ok {
+			t.Errorf("registry missing provider %q", name)
+			continue
+		}
+		if got := p.Name(); got != name {
+			t.Errorf("provider %q Name() = %q, want %q", name, got, name)
+		}
+	}
+}
+
 func TestAuthenticationFlow_FullLifecycle(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/examples/authn/main_test.go
+++ b/examples/authn/main_test.go
@@ -15,8 +15,13 @@ func TestProviderRegistry_RegistersExpectedProviders(t *testing.T) {
 	t.Parallel()
 
 	registry := BuildProviderRegistry()
+	expected := []string{"mock-idp", "netsuite"}
 
-	for _, name := range []string{"mock-idp", "netsuite"} {
+	if len(registry) != len(expected) {
+		t.Errorf("registry size = %d, want %d (keys: %v)", len(registry), len(expected), keysOf(registry))
+	}
+
+	for _, name := range expected {
 		p, ok := registry[name]
 		if !ok {
 			t.Errorf("registry missing provider %q", name)
@@ -26,6 +31,14 @@ func TestProviderRegistry_RegistersExpectedProviders(t *testing.T) {
 			t.Errorf("provider %q Name() = %q, want %q", name, got, name)
 		}
 	}
+}
+
+func keysOf(m application.OAuthProviderRegistry) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestAuthenticationFlow_FullLifecycle(t *testing.T) {

--- a/examples/authn/provider_catalog.go
+++ b/examples/authn/provider_catalog.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/providers"
+)
+
+// BuildProviderRegistry assembles the OAuth provider catalog used by this
+// example service. A real downstream service would copy this shape and
+// populate the configs from env / Viper / Vault, dropping providers it does
+// not need.
+//
+// The mock provider is what RunAuthenticationFlow drives end-to-end; the real
+// providers are registered here to demonstrate the wiring shape — none of
+// their constructors make network calls, so they are safe to construct with
+// placeholder credentials in this example.
+func BuildProviderRegistry() application.OAuthProviderRegistry {
+	mock := NewMockOAuthProvider("mock-idp")
+
+	netsuite := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:     "your-netsuite-client-id",
+		ClientSecret: "your-netsuite-client-secret",
+		AccountID:    "1234567", // sandbox: "1234567_SB1" — auto-normalized to "1234567-sb1" in URLs
+		// AuthEndpoint / TokenEndpoint / RevokeEndpoint / UserInfoEndpoint
+		// can be set to point at a non-standard NetSuite host (e.g. a corporate
+		// proxy or a future endpoint change). Each takes precedence over the
+		// AccountID-derived URL when set.
+	})
+
+	return application.OAuthProviderRegistry{
+		"mock-idp": mock,
+		"netsuite": netsuite,
+	}
+}

--- a/pkg/auth/PROVIDERS.md
+++ b/pkg/auth/PROVIDERS.md
@@ -1,0 +1,119 @@
+# Pericarp OAuth Provider Catalog
+
+Each constructor returns a value that implements
+`application.OAuthProvider` and can be registered in an
+`application.OAuthProviderRegistry`. See `examples/authn/provider_catalog.go`
+for a copy-pasteable wiring example.
+
+---
+
+## Apple
+
+```go
+providers.NewApple(providers.AppleConfig{
+    ClientID:   "com.example.app.web",       // Services ID
+    TeamID:     "ABCDE12345",                 // Apple Developer Team ID
+    KeyID:      "ABC123DEFG",                 // Key ID for the .p8 private key
+    PrivateKey: os.Getenv("APPLE_PRIVATE_KEY"), // PEM-encoded .p8 file contents
+})
+```
+
+Default scopes: `["name", "email"]`. Apple does not support PKCE — the
+`codeVerifier` argument to `Exchange` is ignored. Apple also does not return a
+new ID token on refresh, so `RefreshToken` returns minimal user info.
+
+## GitHub
+
+```go
+providers.NewGitHub(providers.GitHubConfig{
+    ClientID:     os.Getenv("GITHUB_CLIENT_ID"),
+    ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
+})
+```
+
+Default scopes: `["read:user", "user:email"]`. GitHub does not issue OIDC ID
+tokens, so `ValidateIDToken` returns an error; user info is fetched via
+`Exchange`. Refresh tokens are not supported.
+
+## Google
+
+```go
+providers.NewGoogle(providers.GoogleConfig{
+    ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+    ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+})
+```
+
+Default scopes: `["openid", "email", "profile"]`.
+
+## Microsoft
+
+```go
+providers.NewMicrosoft(providers.MicrosoftConfig{
+    ClientID:     os.Getenv("MS_CLIENT_ID"),
+    ClientSecret: os.Getenv("MS_CLIENT_SECRET"),
+    TenantID:     "common", // or a specific tenant GUID / domain
+})
+```
+
+Default scopes: `["openid", "email", "profile", "offline_access"]`. The auth
+and token URLs are templated per `TenantID`. Microsoft v2.0 does not support
+token revocation, so `RevokeToken` returns an error.
+
+## NetSuite
+
+```go
+providers.NewNetSuite(providers.NetSuiteConfig{
+    ClientID:     os.Getenv("NETSUITE_CLIENT_ID"),
+    ClientSecret: os.Getenv("NETSUITE_CLIENT_SECRET"),
+    AccountID:    "1234567", // your NetSuite account ID
+})
+```
+
+Default scopes: `["rest_webservices"]` — required to call NetSuite's
+userinfo endpoint after token issuance.
+
+### Per-account URL templating
+
+Auth, token, revoke, and userinfo URLs are derived from `AccountID` using
+NetSuite's documented host pattern:
+
+| Endpoint  | Default URL |
+| --------- | ----------- |
+| Auth      | `https://<account>.app.netsuite.com/app/login/oauth2/authorize.nl` |
+| Token     | `https://<account>.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token` |
+| Revoke    | `https://<account>.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/revoke` |
+| User info | `https://<account>.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/userinfo` |
+
+NetSuite requires sandbox account IDs to use a hyphen and lowercase in URL
+hosts (per their docs). The provider performs that normalization for you, so
+a sandbox account `"1234567_SB1"` resolves to
+`https://1234567-sb1.app.netsuite.com/...` automatically:
+
+```go
+providers.NewNetSuite(providers.NetSuiteConfig{
+    ClientID:     os.Getenv("NETSUITE_CLIENT_ID"),
+    ClientSecret: os.Getenv("NETSUITE_CLIENT_SECRET"),
+    AccountID:    "1234567_SB1", // -> "1234567-sb1" in URLs
+})
+```
+
+### Endpoint overrides
+
+Each endpoint can be overridden on the config. **An override always wins,
+even when `AccountID` is set** — that is the safety valve for sandboxes whose
+hosts deviate from the standard pattern, and for any future NetSuite endpoint
+change that ships before a Pericarp release:
+
+```go
+providers.NewNetSuite(providers.NetSuiteConfig{
+    ClientID:      os.Getenv("NETSUITE_CLIENT_ID"),
+    ClientSecret:  os.Getenv("NETSUITE_CLIENT_SECRET"),
+    AccountID:     "1234567_SB1",
+    TokenEndpoint: "https://corporate-proxy.example.com/netsuite/token",
+})
+```
+
+`ValidateIDToken` returns `ErrNetSuiteIDTokenNotSupported` because NetSuite's
+OAuth 2.0 implementation does not reliably issue OIDC-conformant ID tokens;
+user info is fetched via `Exchange`.

--- a/pkg/auth/infrastructure/providers/netsuite.go
+++ b/pkg/auth/infrastructure/providers/netsuite.go
@@ -1,0 +1,343 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+)
+
+// NetSuite OAuth 2.0 host pattern templates. The placeholder is replaced with
+// the normalized account ID. Auth runs on app.netsuite.com; token, revoke and
+// userinfo run on suitetalk.api.netsuite.com.
+//
+// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
+const (
+	netSuiteAuthURLTemplate     = "https://%s.app.netsuite.com/app/login/oauth2/authorize.nl"
+	netSuiteTokenURLTemplate    = "https://%s.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token"
+	netSuiteRevokeURLTemplate   = "https://%s.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/revoke"
+	netSuiteUserInfoURLTemplate = "https://%s.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/userinfo"
+)
+
+// ErrNetSuiteIDTokenNotSupported is returned by NetSuite.ValidateIDToken
+// because NetSuite's OAuth 2.0 implementation does not reliably issue
+// OIDC-conformant ID tokens. Use Exchange to fetch user info from NetSuite's
+// userinfo endpoint instead.
+//
+// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
+var ErrNetSuiteIDTokenNotSupported = errors.New("netsuite: OAuth 2.0 ID tokens are not supported; use Exchange to obtain user info")
+
+// NetSuiteConfig holds the configuration for the NetSuite OAuth 2.0 provider.
+//
+// AccountID is required to derive the per-account hosts. Endpoint overrides
+// take precedence over the derived URLs even when AccountID is set — that is
+// the safety valve for sandboxes with non-standard hosts and for any future
+// NetSuite endpoint change.
+type NetSuiteConfig struct {
+	ClientID     string
+	ClientSecret string
+	AccountID    string   // e.g. "1234567" (prod) or "1234567_SB1" (sandbox)
+	Scopes       []string // defaults to ["restlets"]
+
+	// Endpoint overrides. When set, each takes precedence over the
+	// account-derived URL. An empty string falls through to the derived URL.
+	AuthEndpoint     string
+	TokenEndpoint    string
+	RevokeEndpoint   string
+	UserInfoEndpoint string
+}
+
+// NetSuite implements the application.OAuthProvider interface for NetSuite OAuth 2.0.
+type NetSuite struct {
+	clientID         string
+	clientSecret     string
+	accountID        string
+	scopes           []string
+	authEndpoint     string
+	tokenEndpoint    string
+	revokeEndpoint   string
+	userInfoEndpoint string
+	httpClient       *http.Client
+}
+
+// NewNetSuite creates a new NetSuite OAuth provider from the given configuration.
+// If no scopes are provided, it defaults to ["restlets"].
+func NewNetSuite(config NetSuiteConfig) *NetSuite {
+	scopes := config.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"restlets"}
+	}
+
+	return &NetSuite{
+		clientID:         config.ClientID,
+		clientSecret:     config.ClientSecret,
+		accountID:        config.AccountID,
+		scopes:           scopes,
+		authEndpoint:     config.AuthEndpoint,
+		tokenEndpoint:    config.TokenEndpoint,
+		revokeEndpoint:   config.RevokeEndpoint,
+		userInfoEndpoint: config.UserInfoEndpoint,
+		httpClient:       &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Name returns the provider identifier.
+func (n *NetSuite) Name() string {
+	return "netsuite"
+}
+
+// hostAccount normalizes the account ID for use in NetSuite hostnames per
+// NetSuite docs: lowercase and replace underscores with dashes (so a sandbox
+// "1234567_SB1" becomes "1234567-sb1" in URLs).
+func (n *NetSuite) hostAccount() string {
+	return strings.ToLower(strings.ReplaceAll(n.accountID, "_", "-"))
+}
+
+// authURL returns the auth endpoint, preferring the explicit override.
+func (n *NetSuite) authURL() string {
+	if n.authEndpoint != "" {
+		return n.authEndpoint
+	}
+	return fmt.Sprintf(netSuiteAuthURLTemplate, n.hostAccount())
+}
+
+// tokenURL returns the token endpoint, preferring the explicit override.
+func (n *NetSuite) tokenURL() string {
+	if n.tokenEndpoint != "" {
+		return n.tokenEndpoint
+	}
+	return fmt.Sprintf(netSuiteTokenURLTemplate, n.hostAccount())
+}
+
+// revokeURL returns the revoke endpoint, preferring the explicit override.
+func (n *NetSuite) revokeURL() string {
+	if n.revokeEndpoint != "" {
+		return n.revokeEndpoint
+	}
+	return fmt.Sprintf(netSuiteRevokeURLTemplate, n.hostAccount())
+}
+
+// userInfoURL returns the userinfo endpoint, preferring the explicit override.
+func (n *NetSuite) userInfoURL() string {
+	if n.userInfoEndpoint != "" {
+		return n.userInfoEndpoint
+	}
+	return fmt.Sprintf(netSuiteUserInfoURLTemplate, n.hostAccount())
+}
+
+// AuthCodeURL generates the NetSuite authorization URL with PKCE parameters.
+func (n *NetSuite) AuthCodeURL(state string, codeChallenge string, nonce string, redirectURI string) string {
+	params := url.Values{
+		"client_id":             {n.clientID},
+		"redirect_uri":          {redirectURI},
+		"response_type":         {"code"},
+		"scope":                 {strings.Join(n.scopes, " ")},
+		"state":                 {state},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+		"nonce":                 {nonce},
+	}
+	return n.authURL() + "?" + params.Encode()
+}
+
+// netSuiteTokenResponse mirrors the JSON response from NetSuite's token endpoint.
+type netSuiteTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// netSuiteUserInfo mirrors the OIDC-shaped userinfo response from NetSuite.
+type netSuiteUserInfo struct {
+	Sub               string `json:"sub"`
+	Email             string `json:"email"`
+	Name              string `json:"name"`
+	PreferredUsername string `json:"preferred_username"`
+}
+
+// Exchange exchanges an authorization code for tokens and fetches user info.
+func (n *NetSuite) Exchange(ctx context.Context, code string, codeVerifier string, redirectURI string) (*application.AuthResult, error) {
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {codeVerifier},
+	}
+
+	tokenResp, err := n.requestToken(ctx, data)
+	if err != nil {
+		return nil, fmt.Errorf("netsuite: token exchange failed: %w", err)
+	}
+
+	userInfo, err := n.fetchUserInfo(ctx, tokenResp.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("netsuite: failed to fetch user info: %w", err)
+	}
+
+	return &application.AuthResult{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		IDToken:      tokenResp.IDToken,
+		TokenType:    tokenResp.TokenType,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		UserInfo:     *userInfo,
+	}, nil
+}
+
+// RefreshToken refreshes an access token using a refresh token.
+func (n *NetSuite) RefreshToken(ctx context.Context, refreshToken string) (*application.AuthResult, error) {
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+
+	tokenResp, err := n.requestToken(ctx, data)
+	if err != nil {
+		return nil, fmt.Errorf("netsuite: token refresh failed: %w", err)
+	}
+
+	// NetSuite may not return a new refresh token on refresh; preserve the original.
+	if tokenResp.RefreshToken == "" {
+		tokenResp.RefreshToken = refreshToken
+	}
+
+	userInfo, err := n.fetchUserInfo(ctx, tokenResp.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("netsuite: failed to fetch user info after refresh: %w", err)
+	}
+
+	return &application.AuthResult{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		IDToken:      tokenResp.IDToken,
+		TokenType:    tokenResp.TokenType,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		UserInfo:     *userInfo,
+	}, nil
+}
+
+// RevokeToken revokes a token at NetSuite's revocation endpoint (RFC 7009).
+// The client authenticates to NetSuite via HTTP Basic.
+func (n *NetSuite) RevokeToken(ctx context.Context, token string) error {
+	data := url.Values{
+		"token": {token},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.revokeURL(), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("netsuite: failed to create revoke request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(n.clientID, n.clientSecret)
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("netsuite: revoke request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("netsuite: revoke failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ValidateIDToken returns ErrNetSuiteIDTokenNotSupported because NetSuite's
+// OAuth 2.0 implementation does not reliably issue OIDC-conformant ID tokens.
+// Callers should use Exchange (which calls userinfo) to obtain user info.
+//
+// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
+func (n *NetSuite) ValidateIDToken(_ context.Context, _ string, _ string) (*application.UserInfo, error) {
+	return nil, ErrNetSuiteIDTokenNotSupported
+}
+
+// requestToken POSTs to NetSuite's token endpoint with HTTP Basic auth and
+// parses the response. NetSuite's OAuth 2.0 token endpoint expects credentials
+// via the Authorization header, not in the request body.
+func (n *NetSuite) requestToken(ctx context.Context, data url.Values) (*netSuiteTokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.tokenURL(), strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(n.clientID, n.clientSecret)
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token request returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp netSuiteTokenResponse
+	if err = json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+// fetchUserInfo retrieves user information from NetSuite's userinfo endpoint
+// using a Bearer access token.
+func (n *NetSuite) fetchUserInfo(ctx context.Context, accessToken string) (*application.UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, n.userInfoURL(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("userinfo request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read userinfo response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("userinfo request returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var info netSuiteUserInfo
+	if err = json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
+	}
+
+	displayName := info.Name
+	if displayName == "" {
+		displayName = info.PreferredUsername
+	}
+
+	return &application.UserInfo{
+		ProviderUserID: info.Sub,
+		Email:          info.Email,
+		DisplayName:    displayName,
+		AvatarURL:      "",
+		Provider:       "netsuite",
+	}, nil
+}

--- a/pkg/auth/infrastructure/providers/netsuite.go
+++ b/pkg/auth/infrastructure/providers/netsuite.go
@@ -18,7 +18,8 @@ import (
 // the normalized account ID. Auth runs on app.netsuite.com; token, revoke and
 // userinfo run on suitetalk.api.netsuite.com.
 //
-// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// Reference: NetSuite Help > Integration > SuiteCloud Platform >
+// "OAuth 2.0 for Integration"
 // https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
 const (
 	netSuiteAuthURLTemplate     = "https://%s.app.netsuite.com/app/login/oauth2/authorize.nl"
@@ -32,7 +33,8 @@ const (
 // OIDC-conformant ID tokens. Use Exchange to fetch user info from NetSuite's
 // userinfo endpoint instead.
 //
-// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// Reference: NetSuite Help > Integration > SuiteCloud Platform >
+// "OAuth 2.0 for Integration"
 // https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
 var ErrNetSuiteIDTokenNotSupported = errors.New("netsuite: OAuth 2.0 ID tokens are not supported; use Exchange to obtain user info")
 
@@ -46,7 +48,7 @@ type NetSuiteConfig struct {
 	ClientID     string
 	ClientSecret string
 	AccountID    string   // e.g. "1234567" (prod) or "1234567_SB1" (sandbox)
-	Scopes       []string // defaults to ["restlets"]
+	Scopes       []string // defaults to ["rest_webservices"]
 
 	// Endpoint overrides. When set, each takes precedence over the
 	// account-derived URL. An empty string falls through to the derived URL.
@@ -70,11 +72,12 @@ type NetSuite struct {
 }
 
 // NewNetSuite creates a new NetSuite OAuth provider from the given configuration.
-// If no scopes are provided, it defaults to ["restlets"].
+// If no scopes are provided, it defaults to ["rest_webservices"] — the SuiteTalk
+// REST scope that authorizes the userinfo endpoint Exchange calls after token issuance.
 func NewNetSuite(config NetSuiteConfig) *NetSuite {
 	scopes := config.Scopes
 	if len(scopes) == 0 {
-		scopes = []string{"restlets"}
+		scopes = []string{"rest_webservices"}
 	}
 
 	return &NetSuite{
@@ -95,14 +98,13 @@ func (n *NetSuite) Name() string {
 	return "netsuite"
 }
 
-// hostAccount normalizes the account ID for use in NetSuite hostnames per
-// NetSuite docs: lowercase and replace underscores with dashes (so a sandbox
-// "1234567_SB1" becomes "1234567-sb1" in URLs).
+// hostAccount normalizes the account ID for use in NetSuite hostnames:
+// lowercase and replace underscores with dashes. Per NetSuite docs, sandbox
+// accounts (e.g. "1234567_SB1") must use dashes in the URL host ("1234567-sb1").
 func (n *NetSuite) hostAccount() string {
 	return strings.ToLower(strings.ReplaceAll(n.accountID, "_", "-"))
 }
 
-// authURL returns the auth endpoint, preferring the explicit override.
 func (n *NetSuite) authURL() string {
 	if n.authEndpoint != "" {
 		return n.authEndpoint
@@ -110,7 +112,6 @@ func (n *NetSuite) authURL() string {
 	return fmt.Sprintf(netSuiteAuthURLTemplate, n.hostAccount())
 }
 
-// tokenURL returns the token endpoint, preferring the explicit override.
 func (n *NetSuite) tokenURL() string {
 	if n.tokenEndpoint != "" {
 		return n.tokenEndpoint
@@ -118,7 +119,6 @@ func (n *NetSuite) tokenURL() string {
 	return fmt.Sprintf(netSuiteTokenURLTemplate, n.hostAccount())
 }
 
-// revokeURL returns the revoke endpoint, preferring the explicit override.
 func (n *NetSuite) revokeURL() string {
 	if n.revokeEndpoint != "" {
 		return n.revokeEndpoint
@@ -126,7 +126,6 @@ func (n *NetSuite) revokeURL() string {
 	return fmt.Sprintf(netSuiteRevokeURLTemplate, n.hostAccount())
 }
 
-// userInfoURL returns the userinfo endpoint, preferring the explicit override.
 func (n *NetSuite) userInfoURL() string {
 	if n.userInfoEndpoint != "" {
 		return n.userInfoEndpoint
@@ -149,16 +148,16 @@ func (n *NetSuite) AuthCodeURL(state string, codeChallenge string, nonce string,
 	return n.authURL() + "?" + params.Encode()
 }
 
-// netSuiteTokenResponse mirrors the JSON response from NetSuite's token endpoint.
 type netSuiteTokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	IDToken      string `json:"id_token"`
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int    `json:"expires_in"`
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	IDToken          string `json:"id_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int    `json:"expires_in"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
 }
 
-// netSuiteUserInfo mirrors the OIDC-shaped userinfo response from NetSuite.
 type netSuiteUserInfo struct {
 	Sub               string `json:"sub"`
 	Email             string `json:"email"`
@@ -228,7 +227,8 @@ func (n *NetSuite) RefreshToken(ctx context.Context, refreshToken string) (*appl
 }
 
 // RevokeToken revokes a token at NetSuite's revocation endpoint (RFC 7009).
-// The client authenticates to NetSuite via HTTP Basic.
+// NetSuite mandates HTTP Basic on this endpoint; form-encoded
+// client_id/client_secret is rejected.
 func (n *NetSuite) RevokeToken(ctx context.Context, token string) error {
 	data := url.Values{
 		"token": {token},
@@ -259,15 +259,18 @@ func (n *NetSuite) RevokeToken(ctx context.Context, token string) error {
 // OAuth 2.0 implementation does not reliably issue OIDC-conformant ID tokens.
 // Callers should use Exchange (which calls userinfo) to obtain user info.
 //
-// Reference: NetSuite Help "OAuth 2.0 for Integration"
+// Reference: NetSuite Help > Integration > SuiteCloud Platform >
+// "OAuth 2.0 for Integration"
 // https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157771733782.html
 func (n *NetSuite) ValidateIDToken(_ context.Context, _ string, _ string) (*application.UserInfo, error) {
 	return nil, ErrNetSuiteIDTokenNotSupported
 }
 
-// requestToken POSTs to NetSuite's token endpoint with HTTP Basic auth and
-// parses the response. NetSuite's OAuth 2.0 token endpoint expects credentials
-// via the Authorization header, not in the request body.
+// requestToken POSTs to NetSuite's token endpoint. NetSuite expects client
+// credentials via HTTP Basic, not in the request body. NetSuite can also
+// return 200 with an OAuth 2.0 error body (RFC 6749 §5.2-style) — the empty
+// AccessToken / non-empty Error guards below catch that case so callers don't
+// proceed with a blank Bearer token.
 func (n *NetSuite) requestToken(ctx context.Context, data url.Values) (*netSuiteTokenResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.tokenURL(), strings.NewReader(data.Encode()))
 	if err != nil {
@@ -296,11 +299,16 @@ func (n *NetSuite) requestToken(ctx context.Context, data url.Values) (*netSuite
 		return nil, fmt.Errorf("failed to parse token response: %w", err)
 	}
 
+	if tokenResp.Error != "" {
+		return nil, fmt.Errorf("token endpoint error: %s - %s", tokenResp.Error, tokenResp.ErrorDescription)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+
 	return &tokenResp, nil
 }
 
-// fetchUserInfo retrieves user information from NetSuite's userinfo endpoint
-// using a Bearer access token.
 func (n *NetSuite) fetchUserInfo(ctx context.Context, accessToken string) (*application.UserInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, n.userInfoURL(), nil)
 	if err != nil {
@@ -326,6 +334,12 @@ func (n *NetSuite) fetchUserInfo(ctx context.Context, accessToken string) (*appl
 	var info netSuiteUserInfo
 	if err = json.Unmarshal(body, &info); err != nil {
 		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
+	}
+
+	// Guard against silently issuing an identity with an empty ProviderUserID
+	// when NetSuite returns a partial / non-standard userinfo payload.
+	if info.Sub == "" {
+		return nil, fmt.Errorf("userinfo response missing sub")
 	}
 
 	displayName := info.Name

--- a/pkg/auth/infrastructure/providers/netsuite.go
+++ b/pkg/auth/infrastructure/providers/netsuite.go
@@ -134,6 +134,9 @@ func (n *NetSuite) userInfoURL() string {
 }
 
 // AuthCodeURL generates the NetSuite authorization URL with PKCE parameters.
+// The base auth URL may carry its own query string when AuthEndpoint is
+// overridden, so we parse it and merge — direct concatenation with "?" would
+// produce a malformed URL ("?a=1?client_id=...") in that case.
 func (n *NetSuite) AuthCodeURL(state string, codeChallenge string, nonce string, redirectURI string) string {
 	params := url.Values{
 		"client_id":             {n.clientID},
@@ -145,7 +148,22 @@ func (n *NetSuite) AuthCodeURL(state string, codeChallenge string, nonce string,
 		"code_challenge_method": {"S256"},
 		"nonce":                 {nonce},
 	}
-	return n.authURL() + "?" + params.Encode()
+
+	base := n.authURL()
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return base + "?" + params.Encode()
+	}
+
+	query := parsed.Query()
+	for key, values := range params {
+		query.Del(key)
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
 }
 
 type netSuiteTokenResponse struct {
@@ -252,6 +270,8 @@ func (n *NetSuite) RevokeToken(ctx context.Context, token string) error {
 		return fmt.Errorf("netsuite: revoke failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
+	// Drain the body so the underlying connection can be reused by Transport.
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 

--- a/pkg/auth/infrastructure/providers/netsuite_internal_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_internal_test.go
@@ -1,0 +1,80 @@
+package providers
+
+import "testing"
+
+// TestNetSuiteURLBuilders_Derived locks down the per-account URL templating
+// for token, revoke, and userinfo. The exported AuthCodeURL test covers the
+// auth template; this file covers the three other builders that are otherwise
+// only exercised through httptest with overrides set.
+func TestNetSuiteURLBuilders_Derived(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		accountID      string
+		wantToken      string
+		wantRevoke     string
+		wantUserInfo   string
+	}{
+		{
+			name:         "production account",
+			accountID:    "1234567",
+			wantToken:    "https://1234567.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token",
+			wantRevoke:   "https://1234567.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/revoke",
+			wantUserInfo: "https://1234567.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/userinfo",
+		},
+		{
+			name:         "sandbox account normalized",
+			accountID:    "1234567_SB1",
+			wantToken:    "https://1234567-sb1.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token",
+			wantRevoke:   "https://1234567-sb1.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/revoke",
+			wantUserInfo: "https://1234567-sb1.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/userinfo",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			n := NewNetSuite(NetSuiteConfig{AccountID: tt.accountID})
+			if got := n.tokenURL(); got != tt.wantToken {
+				t.Errorf("tokenURL() = %q, want %q", got, tt.wantToken)
+			}
+			if got := n.revokeURL(); got != tt.wantRevoke {
+				t.Errorf("revokeURL() = %q, want %q", got, tt.wantRevoke)
+			}
+			if got := n.userInfoURL(); got != tt.wantUserInfo {
+				t.Errorf("userInfoURL() = %q, want %q", got, tt.wantUserInfo)
+			}
+		})
+	}
+}
+
+// TestNetSuiteURLBuilders_OverrideWins asserts the override-wins-over-derived
+// rule for every endpoint, including revoke and userinfo where the exported
+// surface didn't otherwise give us a way to assert it directly.
+func TestNetSuiteURLBuilders_OverrideWins(t *testing.T) {
+	t.Parallel()
+
+	n := NewNetSuite(NetSuiteConfig{
+		AccountID:        "1234567",
+		AuthEndpoint:     "https://override.example.com/auth",
+		TokenEndpoint:    "https://override.example.com/token",
+		RevokeEndpoint:   "https://override.example.com/revoke",
+		UserInfoEndpoint: "https://override.example.com/userinfo",
+	})
+
+	if got := n.authURL(); got != "https://override.example.com/auth" {
+		t.Errorf("authURL() = %q, want override", got)
+	}
+	if got := n.tokenURL(); got != "https://override.example.com/token" {
+		t.Errorf("tokenURL() = %q, want override", got)
+	}
+	if got := n.revokeURL(); got != "https://override.example.com/revoke" {
+		t.Errorf("revokeURL() = %q, want override", got)
+	}
+	if got := n.userInfoURL(); got != "https://override.example.com/userinfo" {
+		t.Errorf("userInfoURL() = %q, want override", got)
+	}
+}

--- a/pkg/auth/infrastructure/providers/netsuite_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_test.go
@@ -108,9 +108,9 @@ func TestNetSuite_AuthCodeURL_OverrideWinsOverDerived(t *testing.T) {
 func TestNetSuite_TokenURL_OverrideWinsOverDerived(t *testing.T) {
 	t.Parallel()
 
-	var hit string
+	hits := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hit = r.URL.Path
+		hits <- r.URL.Path
 		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
 	}))
 	defer srv.Close()
@@ -132,7 +132,7 @@ func TestNetSuite_TokenURL_OverrideWinsOverDerived(t *testing.T) {
 	if _, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb"); err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
-	if hit != "/token" {
+	if hit := <-hits; hit != "/token" {
 		t.Errorf("token endpoint hit = %q, want %q (override should win over derived URL)", hit, "/token")
 	}
 }
@@ -418,9 +418,9 @@ func TestNetSuite_ValidateIDToken_ReturnsSentinel(t *testing.T) {
 func TestNetSuite_RevokeURL_OverrideWinsOverDerived(t *testing.T) {
 	t.Parallel()
 
-	var hit string
+	hits := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hit = r.URL.Path
+		hits <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -435,7 +435,7 @@ func TestNetSuite_RevokeURL_OverrideWinsOverDerived(t *testing.T) {
 	if err := n.RevokeToken(context.Background(), "tok"); err != nil {
 		t.Fatalf("RevokeToken: %v", err)
 	}
-	if hit != "/revoke" {
+	if hit := <-hits; hit != "/revoke" {
 		t.Errorf("revoke endpoint hit = %q, want %q (override should win over derived URL)", hit, "/revoke")
 	}
 }
@@ -450,9 +450,9 @@ func TestNetSuite_UserInfoURL_OverrideWinsOverDerived(t *testing.T) {
 	}))
 	defer tokenSrv.Close()
 
-	var hit string
+	hits := make(chan string, 1)
 	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hit = r.URL.Path
+		hits <- r.URL.Path
 		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1", Email: "u@example.com"})
 	}))
 	defer userSrv.Close()
@@ -468,7 +468,7 @@ func TestNetSuite_UserInfoURL_OverrideWinsOverDerived(t *testing.T) {
 	if _, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb"); err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
-	if hit != "/userinfo" {
+	if hit := <-hits; hit != "/userinfo" {
 		t.Errorf("userinfo endpoint hit = %q, want %q (override should win over derived URL)", hit, "/userinfo")
 	}
 }

--- a/pkg/auth/infrastructure/providers/netsuite_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_test.go
@@ -37,8 +37,11 @@ func TestNetSuite_DefaultScopes(t *testing.T) {
 		t.Fatalf("parse auth URL: %v", err)
 	}
 
-	if got := parsed.Query().Get("scope"); got != "restlets" {
-		t.Errorf("default scope = %q, want %q", got, "restlets")
+	// rest_webservices is the SuiteTalk REST scope that authorizes the
+	// userinfo endpoint Exchange calls after token issuance — defaulting
+	// elsewhere would make the default Exchange flow fail.
+	if got := parsed.Query().Get("scope"); got != "rest_webservices" {
+		t.Errorf("default scope = %q, want %q", got, "rest_webservices")
 	}
 }
 
@@ -409,14 +412,277 @@ func TestNetSuite_ValidateIDToken_ReturnsSentinel(t *testing.T) {
 	}
 }
 
+// TestNetSuite_RevokeURL_OverrideWinsOverDerived covers the same trap as for
+// auth/token: explicit override must win over the derived URL even when
+// AccountID is set.
+func TestNetSuite_RevokeURL_OverrideWinsOverDerived(t *testing.T) {
+	t.Parallel()
+
+	var hit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:       "id",
+		ClientSecret:   "secret",
+		AccountID:      "1234567",
+		RevokeEndpoint: srv.URL + "/revoke",
+	})
+
+	if err := n.RevokeToken(context.Background(), "tok"); err != nil {
+		t.Fatalf("RevokeToken: %v", err)
+	}
+	if hit != "/revoke" {
+		t.Errorf("revoke endpoint hit = %q, want %q (override should win over derived URL)", hit, "/revoke")
+	}
+}
+
+// TestNetSuite_UserInfoURL_OverrideWinsOverDerived covers the same trap for
+// the userinfo endpoint.
+func TestNetSuite_UserInfoURL_OverrideWinsOverDerived(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer tokenSrv.Close()
+
+	var hit string
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = r.URL.Path
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1", Email: "u@example.com"})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL + "/userinfo",
+	})
+
+	if _, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb"); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if hit != "/userinfo" {
+		t.Errorf("userinfo endpoint hit = %q, want %q (override should win over derived URL)", hit, "/userinfo")
+	}
+}
+
+// TestNetSuite_Exchange_UserInfoFailure asserts that a userinfo failure after
+// a successful token exchange propagates as an error rather than being
+// silently masked into a partial AuthResult.
+func TestNetSuite_Exchange_UserInfoFailure(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"backend"}`))
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	_, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb")
+	if err == nil {
+		t.Fatal("expected error from Exchange when userinfo returns 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch user info") {
+		t.Errorf("error = %v, want it to mention failed to fetch user info", err)
+	}
+}
+
+// TestNetSuite_RefreshToken_UserInfoFailure asserts the same propagation on
+// the refresh path; the error message must distinguish refresh from initial
+// exchange.
+func TestNetSuite_RefreshToken_UserInfoFailure(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	_, err := n.RefreshToken(context.Background(), "old-refresh")
+	if err == nil {
+		t.Fatal("expected error from RefreshToken when userinfo returns 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch user info after refresh") {
+		t.Errorf("error = %v, want refresh-specific user info failure message", err)
+	}
+}
+
+// TestNetSuite_Exchange_TokenSuccessWithoutAccessToken guards against a
+// silent-failure mode: NetSuite (or a fronting proxy) returns 200 with an
+// OAuth error body or empty access_token. We must NOT then call userinfo with
+// an empty Bearer token.
+func TestNetSuite_Exchange_TokenSuccessWithoutAccessToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    netSuiteTokenStub
+		wantSub string
+	}{
+		{
+			name:    "OAuth error body on 200",
+			body:    netSuiteTokenStub{Error: "invalid_grant", ErrorDescription: "code expired"},
+			wantSub: "token endpoint error",
+		},
+		{
+			name:    "missing access_token on 200",
+			body:    netSuiteTokenStub{TokenType: "Bearer", ExpiresIn: 3600},
+			wantSub: "missing access_token",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeTokenResponse(t, w, tt.body)
+			}))
+			defer tokenSrv.Close()
+
+			userInfoCalled := false
+			userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				userInfoCalled = true
+				writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1"})
+			}))
+			defer userSrv.Close()
+
+			n := providers.NewNetSuite(providers.NetSuiteConfig{
+				ClientID:         "id",
+				ClientSecret:     "secret",
+				AccountID:        "1234567",
+				TokenEndpoint:    tokenSrv.URL,
+				UserInfoEndpoint: userSrv.URL,
+			})
+
+			_, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb")
+			if err == nil {
+				t.Fatal("expected error from Exchange, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error = %v, want it to mention %q", err, tt.wantSub)
+			}
+			if userInfoCalled {
+				t.Error("userinfo must not be called when token endpoint did not return a usable access_token")
+			}
+		})
+	}
+}
+
+// TestNetSuite_Exchange_UserInfoMissingSub guards against silently issuing an
+// identity with an empty ProviderUserID when NetSuite returns a partial
+// userinfo payload.
+func TestNetSuite_Exchange_UserInfoMissingSub(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Email: "u@example.com"})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	_, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb")
+	if err == nil {
+		t.Fatal("expected error from Exchange when userinfo omits sub, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing sub") {
+		t.Errorf("error = %v, want it to mention missing sub", err)
+	}
+}
+
+// TestNetSuite_Exchange_DisplayNameFallback covers the PreferredUsername
+// fallback NetSuite often returns for service / system accounts that lack a
+// human-readable Name.
+func TestNetSuite_Exchange_DisplayNameFallback(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{
+			Sub:               "user-1",
+			Email:             "svc@example.com",
+			PreferredUsername: "svcaccount",
+		})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	res, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if res.UserInfo.DisplayName != "svcaccount" {
+		t.Errorf("DisplayName = %q, want svcaccount (preferred_username fallback)", res.UserInfo.DisplayName)
+	}
+}
+
 // --- helpers ---
 
 type netSuiteTokenStub struct {
-	AccessToken  string `json:"access_token,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
-	IDToken      string `json:"id_token,omitempty"`
-	TokenType    string `json:"token_type,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
+	AccessToken      string `json:"access_token,omitempty"`
+	RefreshToken     string `json:"refresh_token,omitempty"`
+	IDToken          string `json:"id_token,omitempty"`
+	TokenType        string `json:"token_type,omitempty"`
+	ExpiresIn        int    `json:"expires_in,omitempty"`
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
 }
 
 type netSuiteUserInfoStub struct {

--- a/pkg/auth/infrastructure/providers/netsuite_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_test.go
@@ -1,0 +1,445 @@
+package providers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/providers"
+)
+
+func TestNetSuite_Name(t *testing.T) {
+	t.Parallel()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{AccountID: "1234567"})
+	if got := n.Name(); got != "netsuite" {
+		t.Errorf("Name() = %q, want %q", got, "netsuite")
+	}
+}
+
+func TestNetSuite_DefaultScopes(t *testing.T) {
+	t.Parallel()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:  "client-id",
+		AccountID: "1234567",
+	})
+
+	authURL := n.AuthCodeURL("state", "challenge", "nonce", "https://app.example.com/callback")
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+
+	if got := parsed.Query().Get("scope"); got != "restlets" {
+		t.Errorf("default scope = %q, want %q", got, "restlets")
+	}
+}
+
+func TestNetSuite_AuthCodeURL_DerivedHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		accountID string
+		wantHost  string
+	}{
+		{name: "production account", accountID: "1234567", wantHost: "1234567.app.netsuite.com"},
+		{name: "sandbox account normalized", accountID: "1234567_SB1", wantHost: "1234567-sb1.app.netsuite.com"},
+		{name: "uppercase normalized", accountID: "ABC123", wantHost: "abc123.app.netsuite.com"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			n := providers.NewNetSuite(providers.NetSuiteConfig{
+				ClientID:  "client-id",
+				AccountID: tt.accountID,
+			})
+
+			authURL := n.AuthCodeURL("state", "challenge", "nonce", "https://app.example.com/callback")
+			parsed, err := url.Parse(authURL)
+			if err != nil {
+				t.Fatalf("parse auth URL: %v", err)
+			}
+
+			if parsed.Host != tt.wantHost {
+				t.Errorf("auth host = %q, want %q", parsed.Host, tt.wantHost)
+			}
+			if parsed.Path != "/app/login/oauth2/authorize.nl" {
+				t.Errorf("auth path = %q, want %q", parsed.Path, "/app/login/oauth2/authorize.nl")
+			}
+		})
+	}
+}
+
+func TestNetSuite_AuthCodeURL_OverrideWinsOverDerived(t *testing.T) {
+	t.Parallel()
+
+	// AccountID is set AND override is set; override must win. This is the
+	// trap the issue calls out: "don't fall through to derived only when
+	// AccountID is empty — explicit overrides win".
+	override := "https://sandbox.example.com/auth"
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:     "client-id",
+		AccountID:    "1234567",
+		AuthEndpoint: override,
+	})
+
+	authURL := n.AuthCodeURL("state", "challenge", "nonce", "https://app.example.com/callback")
+	if !strings.HasPrefix(authURL, override+"?") {
+		t.Errorf("auth URL = %q, want prefix %q", authURL, override+"?")
+	}
+}
+
+// TestNetSuite_TokenURL_OverrideWinsOverDerived verifies the override behavior
+// for the token endpoint via the request actually sent to httptest.
+func TestNetSuite_TokenURL_OverrideWinsOverDerived(t *testing.T) {
+	t.Parallel()
+
+	var hit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = r.URL.Path
+		writeTokenResponse(t, w, netSuiteTokenStub{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1", Email: "u@example.com"})
+	}))
+	defer userSrv.Close()
+
+	// AccountID set AND TokenEndpoint override set; override must win.
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    srv.URL + "/token",
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	if _, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb"); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if hit != "/token" {
+		t.Errorf("token endpoint hit = %q, want %q (override should win over derived URL)", hit, "/token")
+	}
+}
+
+func TestNetSuite_Exchange_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("token method = %q, want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("token Content-Type = %q, want %q", got, "application/x-www-form-urlencoded")
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			t.Errorf("token request missing Basic auth")
+		}
+		if user != "client-id" || pass != "client-secret" {
+			t.Errorf("token Basic auth = (%q,%q), want (client-id,client-secret)", user, pass)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read token body: %v", err)
+		}
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parse token form: %v", err)
+		}
+		if got := form.Get("grant_type"); got != "authorization_code" {
+			t.Errorf("grant_type = %q, want authorization_code", got)
+		}
+		if got := form.Get("code"); got != "auth-code-xyz" {
+			t.Errorf("code = %q, want auth-code-xyz", got)
+		}
+		if got := form.Get("code_verifier"); got != "verifier-abc" {
+			t.Errorf("code_verifier = %q, want verifier-abc", got)
+		}
+		if got := form.Get("redirect_uri"); got != "https://app.example.com/cb" {
+			t.Errorf("redirect_uri = %q, want https://app.example.com/cb", got)
+		}
+
+		writeTokenResponse(t, w, netSuiteTokenStub{
+			AccessToken:  "access-123",
+			RefreshToken: "refresh-456",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("userinfo method = %q, want GET", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access-123" {
+			t.Errorf("userinfo Authorization = %q, want %q", got, "Bearer access-123")
+		}
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{
+			Sub:   "user-internal-123",
+			Email: "alice@example.com",
+			Name:  "Alice Doe",
+		})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "client-id",
+		ClientSecret:     "client-secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	res, err := n.Exchange(context.Background(), "auth-code-xyz", "verifier-abc", "https://app.example.com/cb")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if res.AccessToken != "access-123" {
+		t.Errorf("AccessToken = %q, want access-123", res.AccessToken)
+	}
+	if res.RefreshToken != "refresh-456" {
+		t.Errorf("RefreshToken = %q, want refresh-456", res.RefreshToken)
+	}
+	if res.UserInfo.ProviderUserID != "user-internal-123" {
+		t.Errorf("ProviderUserID = %q, want user-internal-123", res.UserInfo.ProviderUserID)
+	}
+	if res.UserInfo.Email != "alice@example.com" {
+		t.Errorf("Email = %q, want alice@example.com", res.UserInfo.Email)
+	}
+	if res.UserInfo.DisplayName != "Alice Doe" {
+		t.Errorf("DisplayName = %q, want Alice Doe", res.UserInfo.DisplayName)
+	}
+	if res.UserInfo.Provider != "netsuite" {
+		t.Errorf("Provider = %q, want netsuite", res.UserInfo.Provider)
+	}
+}
+
+func TestNetSuite_Exchange_TokenEndpointError(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer tokenSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		AccountID:     "1234567",
+		TokenEndpoint: tokenSrv.URL,
+	})
+
+	_, err := n.Exchange(context.Background(), "code", "verifier", "https://app.example.com/cb")
+	if err == nil {
+		t.Fatal("expected error from Exchange when token endpoint returns 400, got nil")
+	}
+	if !strings.Contains(err.Error(), "token exchange failed") {
+		t.Errorf("error = %v, want it to mention token exchange failure", err)
+	}
+}
+
+func TestNetSuite_RefreshToken_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		if got := form.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", got)
+		}
+		if got := form.Get("refresh_token"); got != "old-refresh" {
+			t.Errorf("refresh_token = %q, want old-refresh", got)
+		}
+		writeTokenResponse(t, w, netSuiteTokenStub{
+			AccessToken:  "access-new",
+			RefreshToken: "refresh-new",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1", Email: "u@example.com"})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	res, err := n.RefreshToken(context.Background(), "old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if res.AccessToken != "access-new" {
+		t.Errorf("AccessToken = %q, want access-new", res.AccessToken)
+	}
+	if res.RefreshToken != "refresh-new" {
+		t.Errorf("RefreshToken = %q, want refresh-new", res.RefreshToken)
+	}
+}
+
+func TestNetSuite_RefreshToken_PreservesOriginalWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// No refresh_token in the response body — caller should keep the old one.
+		writeTokenResponse(t, w, netSuiteTokenStub{
+			AccessToken: "access-rolled",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1", Email: "u@example.com"})
+	}))
+	defer userSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		AccountID:        "1234567",
+		TokenEndpoint:    tokenSrv.URL,
+		UserInfoEndpoint: userSrv.URL,
+	})
+
+	res, err := n.RefreshToken(context.Background(), "original-refresh")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if res.RefreshToken != "original-refresh" {
+		t.Errorf("RefreshToken = %q, want original-refresh (preserved)", res.RefreshToken)
+	}
+}
+
+func TestNetSuite_RevokeToken_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	revokeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("revoke method = %q, want POST", r.Method)
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			t.Errorf("revoke missing Basic auth")
+		}
+		if user != "id" || pass != "secret" {
+			t.Errorf("revoke Basic auth = (%q,%q), want (id,secret)", user, pass)
+		}
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		if got := form.Get("token"); got != "to-revoke" {
+			t.Errorf("token = %q, want to-revoke", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer revokeSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:       "id",
+		ClientSecret:   "secret",
+		AccountID:      "1234567",
+		RevokeEndpoint: revokeSrv.URL,
+	})
+
+	if err := n.RevokeToken(context.Background(), "to-revoke"); err != nil {
+		t.Fatalf("RevokeToken: %v", err)
+	}
+}
+
+func TestNetSuite_RevokeToken_NonOKReturnsError(t *testing.T) {
+	t.Parallel()
+
+	revokeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_token"}`))
+	}))
+	defer revokeSrv.Close()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:       "id",
+		ClientSecret:   "secret",
+		AccountID:      "1234567",
+		RevokeEndpoint: revokeSrv.URL,
+	})
+
+	err := n.RevokeToken(context.Background(), "tok")
+	if err == nil {
+		t.Fatal("expected error from RevokeToken when revoke endpoint returns 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "revoke failed with status 401") {
+		t.Errorf("error = %v, want it to mention status 401", err)
+	}
+}
+
+func TestNetSuite_ValidateIDToken_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	n := providers.NewNetSuite(providers.NetSuiteConfig{
+		ClientID:  "id",
+		AccountID: "1234567",
+	})
+
+	_, err := n.ValidateIDToken(context.Background(), "any.id.token", "nonce")
+	if !errors.Is(err, providers.ErrNetSuiteIDTokenNotSupported) {
+		t.Errorf("ValidateIDToken err = %v, want ErrNetSuiteIDTokenNotSupported", err)
+	}
+}
+
+// --- helpers ---
+
+type netSuiteTokenStub struct {
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+}
+
+type netSuiteUserInfoStub struct {
+	Sub               string `json:"sub,omitempty"`
+	Email             string `json:"email,omitempty"`
+	Name              string `json:"name,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+}
+
+func writeTokenResponse(t *testing.T, w http.ResponseWriter, body netSuiteTokenStub) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode token response: %v", err)
+	}
+}
+
+func writeUserInfoResponse(t *testing.T, w http.ResponseWriter, body netSuiteUserInfoStub) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode userinfo response: %v", err)
+	}
+}

--- a/pkg/auth/infrastructure/providers/netsuite_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_test.go
@@ -574,9 +574,12 @@ func TestNetSuite_Exchange_TokenSuccessWithoutAccessToken(t *testing.T) {
 			}))
 			defer tokenSrv.Close()
 
-			userInfoCalled := false
+			userInfoCalls := make(chan struct{}, 1)
 			userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				userInfoCalled = true
+				select {
+				case userInfoCalls <- struct{}{}:
+				default:
+				}
 				writeUserInfoResponse(t, w, netSuiteUserInfoStub{Sub: "u1"})
 			}))
 			defer userSrv.Close()
@@ -596,8 +599,10 @@ func TestNetSuite_Exchange_TokenSuccessWithoutAccessToken(t *testing.T) {
 			if !strings.Contains(err.Error(), tt.wantSub) {
 				t.Errorf("error = %v, want it to mention %q", err, tt.wantSub)
 			}
-			if userInfoCalled {
+			select {
+			case <-userInfoCalls:
 				t.Error("userinfo must not be called when token endpoint did not return a usable access_token")
+			default:
 			}
 		})
 	}

--- a/pkg/auth/infrastructure/providers/netsuite_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_test.go
@@ -157,11 +157,15 @@ func TestNetSuite_Exchange_HappyPath(t *testing.T) {
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read token body: %v", err)
+			t.Errorf("read token body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
 		}
 		form, err := url.ParseQuery(string(body))
 		if err != nil {
-			t.Fatalf("parse token form: %v", err)
+			t.Errorf("parse token form: %v", err)
+			http.Error(w, "parse form", http.StatusInternalServerError)
+			return
 		}
 		if got := form.Get("grant_type"); got != "authorization_code" {
 			t.Errorf("grant_type = %q, want authorization_code", got)
@@ -702,7 +706,7 @@ func writeTokenResponse(t *testing.T, w http.ResponseWriter, body netSuiteTokenS
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
-		t.Fatalf("encode token response: %v", err)
+		t.Errorf("encode token response: %v", err)
 	}
 }
 
@@ -711,6 +715,6 @@ func writeUserInfoResponse(t *testing.T, w http.ResponseWriter, body netSuiteUse
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
-		t.Fatalf("encode userinfo response: %v", err)
+		t.Errorf("encode userinfo response: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #27 and #28 (epic #26). Both stories landed on this branch as requested.

## Story #27 — NetSuite OAuth provider
- `providers.NewNetSuite(NetSuiteConfig{...})` returns an `application.OAuthProvider` for the NetSuite OAuth 2.0 flow
- Per-account hosts derived from `AccountID` using NetSuite's documented host pattern; sandbox normalization (`_` → `-`, lowercase) so `1234567_SB1` resolves to `1234567-sb1.app.netsuite.com` automatically
- Each endpoint takes an explicit override that wins over the derived URL even when `AccountID` is set — safety valve for sandboxes and future NetSuite endpoint changes
- `ValidateIDToken` returns sentinel `ErrNetSuiteIDTokenNotSupported`; user info is fetched via NetSuite's `userinfo` endpoint
- Token endpoint surfaces OAuth 2.0 error bodies returned with HTTP 200 and rejects empty `access_token`; userinfo rejects empty `sub` (silent-failure guards)
- Default scope is `["rest_webservices"]` so `Exchange` works against a real tenant out of the box

## Story #28 — Docs and example wiring
- Added `pkg/auth/PROVIDERS.md` provider catalog with entries for the five shipping providers (Apple, GitHub, Google, Microsoft, NetSuite). NetSuite section covers per-account URL templating, sandbox normalization, and the override fields with a sandbox example
- Added `examples/authn/provider_catalog.go` with `BuildProviderRegistry()` as a copy-pasteable wiring template; `main.go` calls it instead of registering the mock inline
- `TestProviderRegistry_RegistersExpectedProviders` locks the catalog membership and size

## Test plan
- [x] `go test -race ./pkg/auth/...` — green (22 NetSuite cases pass)
- [x] `go test -race ./examples/authn/` — green (registry test asserts NetSuite registered)
- [x] `make lint` — 0 issues
- [x] `make test-unit` — full suite green
- [x] Override-wins-over-derived asserted for all four endpoints (auth/token/revoke/userinfo)
- [x] Sandbox account ID normalization asserted via both AuthCodeURL and direct URL-builder tests
- [x] Exchange/RefreshToken/RevokeToken happy paths against `httptest` fakes
- [x] Userinfo failure during Exchange / RefreshToken (refresh-specific error message)
- [x] Token-endpoint silent-failure modes (200 + OAuth error body, 200 + empty `access_token`)
- [x] Userinfo missing `sub` is rejected
- [x] DisplayName fallback to `preferred_username`
- [x] `ValidateIDToken` returns the sentinel error
- [x] PR review feedback addressed (default scope, silent-failure guards, missing override-wins tests, derived-URL unit tests, comment cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)