### PR TITLE
feat(auth): wire EventDispatcher through DefaultAuthenticationService

### DIFF
--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -178,6 +178,7 @@ type DefaultAuthenticationService struct {
 	accounts            repositories.AccountRepository
 	passwordCredentials repositories.PasswordCredentialRepository
 	eventStore          esDomain.EventStore
+	dispatcher          *esDomain.EventDispatcher
 	tokens              TokenStore
 	authorization       AuthorizationChecker
 	logger              Logger
@@ -359,7 +360,7 @@ func (s *DefaultAuthenticationService) FindOrCreateAgent(ctx context.Context, us
 
 	// Commit events atomically to event store via UnitOfWork
 	if s.eventStore != nil {
-		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
 		if err = uow.Track(agent, account, credential); err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to track entities: %w", err)
 		}
@@ -602,7 +603,7 @@ func (s *DefaultAuthenticationService) RegisterPassword(ctx context.Context, ema
 	}
 
 	if s.eventStore != nil {
-		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
 		if err := uow.Track(agent, account, credential, passwordCredential); err != nil {
 			return nil, nil, nil, fmt.Errorf("authentication: track entities: %w", err)
 		}
@@ -798,7 +799,7 @@ func (s *DefaultAuthenticationService) ImportPasswordCredential(ctx context.Cont
 	}
 
 	if s.eventStore != nil {
-		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
 		if err := uow.Track(credential, passwordCredential); err != nil {
 			return fmt.Errorf("authentication: track entities: %w", err)
 		}
@@ -894,7 +895,7 @@ func (s *DefaultAuthenticationService) UpdatePassword(ctx context.Context, agent
 	}
 
 	if s.eventStore != nil {
-		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, nil)
+		uow := esApplication.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
 		if err := uow.Track(pc); err != nil {
 			return fmt.Errorf("authentication: track password credential: %w", err)
 		}

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -1341,15 +1341,17 @@ func TestFindOrCreateAgent_DispatchesEventsWhenConfigured(t *testing.T) {
 	}
 }
 
-// TestFindOrCreateAgent_NoDispatcherIsDefault verifies that when no
-// EventDispatcher is configured, FindOrCreateAgent succeeds without panicking
-// and the projection writes still land — i.e., omitting WithEventDispatcher
-// is a true no-op for callers who don't need in-process subscribers.
+// TestFindOrCreateAgent_NoDispatcherIsDefault verifies that omitting
+// WithEventDispatcher is a true no-op: FindOrCreateAgent still succeeds, and
+// — critically — events still land in the EventStore. The store readback is
+// what makes this test meaningful (otherwise it would only assert "no panic"),
+// since the visible "events are durable independent of dispatcher" contract
+// is precisely what callers without subscribers depend on.
 func TestFindOrCreateAgent_NoDispatcherIsDefault(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	svc, deps, _ := newServiceWithEventing(t, nil)
+	svc, _, store := newServiceWithEventing(t, nil)
 
 	agent, credential, account, err := svc.FindOrCreateAgent(ctx, application.UserInfo{
 		ProviderUserID: "google-user-nodisp",
@@ -1363,8 +1365,13 @@ func TestFindOrCreateAgent_NoDispatcherIsDefault(t *testing.T) {
 	if agent == nil || credential == nil || account == nil {
 		t.Fatal("expected non-nil agent, credential, and account")
 	}
-	if len(deps.agents.agents) != 1 {
-		t.Errorf("expected 1 saved agent, got %d", len(deps.agents.agents))
+
+	agentEvents, err := store.GetEvents(ctx, agent.GetID())
+	if err != nil {
+		t.Fatalf("store.GetEvents(agent) error: %v", err)
+	}
+	if len(agentEvents) == 0 {
+		t.Error("expected agent events to be durably appended even without a dispatcher")
 	}
 }
 

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -3,6 +3,8 @@ package application_test
 import (
 	"context"
 	"errors"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +12,8 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	esDomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	esInfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
 )
 
 // --- Mock implementations ---
@@ -1242,5 +1246,159 @@ func TestNewDefaultAuthenticationService_NilAuthorization(t *testing.T) {
 	// With nil authorization checker, permissions should be nil/empty
 	if len(info.Permissions) != 0 {
 		t.Errorf("expected 0 permissions with nil authorization checker, got %d", len(info.Permissions))
+	}
+}
+
+// newServiceWithEventing builds the same mock-backed service as newTestService,
+// but additionally wires a real in-memory EventStore and (optionally) an
+// EventDispatcher so callers can assert dispatch behavior.
+func newServiceWithEventing(t *testing.T, dispatcher *esDomain.EventDispatcher) (*application.DefaultAuthenticationService, *testDeps, *esInfra.MemoryStore) {
+	t.Helper()
+	deps := &testDeps{
+		providers: application.OAuthProviderRegistry{
+			"google": &mockOAuthProvider{name: "google"},
+		},
+		agents:      newMockAgentRepo(),
+		credentials: newMockCredentialRepo(),
+		sessions:    newMockSessionRepo(),
+		accounts:    newMockAccountRepo(),
+		tokens:      newMockTokenStore(),
+		authz:       &mockAuthorizationChecker{},
+	}
+	store := esInfra.NewMemoryStore()
+
+	opts := []application.AuthServiceOption{
+		application.WithTokenStore(deps.tokens),
+		application.WithAuthorizationChecker(deps.authz),
+		application.WithEventStore(store),
+	}
+	if dispatcher != nil {
+		opts = append(opts, application.WithEventDispatcher(dispatcher))
+	}
+
+	svc := application.NewDefaultAuthenticationService(
+		deps.providers,
+		deps.agents,
+		deps.credentials,
+		deps.sessions,
+		deps.accounts,
+		opts...,
+	)
+	return svc, deps, store
+}
+
+// TestFindOrCreateAgent_DispatchesEventsWhenConfigured verifies that when an
+// EventDispatcher is wired via WithEventDispatcher, FindOrCreateAgent fans the
+// committed envelopes out to subscribed handlers.
+func TestFindOrCreateAgent_DispatchesEventsWhenConfigured(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	dispatcher := esDomain.NewEventDispatcher()
+
+	var mu sync.Mutex
+	var received []string
+	if err := dispatcher.SubscribeWildcard(func(_ context.Context, env esDomain.EventEnvelope[any]) error {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, env.EventType)
+		return nil
+	}); err != nil {
+		t.Fatalf("SubscribeWildcard() error: %v", err)
+	}
+
+	svc, _, _ := newServiceWithEventing(t, dispatcher)
+
+	if _, _, _, err := svc.FindOrCreateAgent(ctx, application.UserInfo{
+		ProviderUserID: "google-user-dispatch",
+		Email:          "dispatch@example.com",
+		DisplayName:    "Dispatch User",
+		Provider:       "google",
+	}); err != nil {
+		t.Fatalf("FindOrCreateAgent() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	wantTypes := map[string]bool{
+		entities.EventTypeAgentCreated:       false,
+		entities.EventTypeAccountCreated:     false,
+		entities.EventTypeAccountMemberAdded: false,
+		entities.EventTypeCredentialCreated:  false,
+	}
+	for _, et := range received {
+		if _, ok := wantTypes[et]; ok {
+			wantTypes[et] = true
+		}
+	}
+	for et, seen := range wantTypes {
+		if !seen {
+			sorted := append([]string(nil), received...)
+			sort.Strings(sorted)
+			t.Errorf("dispatcher did not receive event %q; got %v", et, sorted)
+		}
+	}
+}
+
+// TestFindOrCreateAgent_NoDispatcherIsDefault verifies that when no
+// EventDispatcher is configured, FindOrCreateAgent succeeds without panicking
+// and the projection writes still land — i.e., omitting WithEventDispatcher
+// is a true no-op for callers who don't need in-process subscribers.
+func TestFindOrCreateAgent_NoDispatcherIsDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps, _ := newServiceWithEventing(t, nil)
+
+	agent, credential, account, err := svc.FindOrCreateAgent(ctx, application.UserInfo{
+		ProviderUserID: "google-user-nodisp",
+		Email:          "nodisp@example.com",
+		DisplayName:    "No Dispatch",
+		Provider:       "google",
+	})
+	if err != nil {
+		t.Fatalf("FindOrCreateAgent() error: %v", err)
+	}
+	if agent == nil || credential == nil || account == nil {
+		t.Fatal("expected non-nil agent, credential, and account")
+	}
+	if len(deps.agents.agents) != 1 {
+		t.Errorf("expected 1 saved agent, got %d", len(deps.agents.agents))
+	}
+}
+
+// TestFindOrCreateAgent_DispatchHandlerErrorIsNonFatal verifies that handler
+// failures are swallowed by SimpleUnitOfWork.Commit (events are already
+// durable post-Append) and do not cause FindOrCreateAgent to fail. This
+// matches the eventually-consistent dispatch contract documented on
+// WithEventDispatcher.
+func TestFindOrCreateAgent_DispatchHandlerErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	dispatcher := esDomain.NewEventDispatcher()
+	if err := dispatcher.SubscribeWildcard(func(_ context.Context, _ esDomain.EventEnvelope[any]) error {
+		return errors.New("handler intentionally failing")
+	}); err != nil {
+		t.Fatalf("SubscribeWildcard() error: %v", err)
+	}
+
+	svc, deps, _ := newServiceWithEventing(t, dispatcher)
+
+	agent, _, _, err := svc.FindOrCreateAgent(ctx, application.UserInfo{
+		ProviderUserID: "google-user-handler-err",
+		Email:          "handler-err@example.com",
+		DisplayName:    "Handler Err",
+		Provider:       "google",
+	})
+	if err != nil {
+		t.Fatalf("FindOrCreateAgent() error despite non-fatal handler failure: %v", err)
+	}
+	if agent == nil {
+		t.Fatal("expected non-nil agent even when handler errors")
+	}
+	if len(deps.agents.agents) != 1 {
+		t.Errorf("expected 1 saved agent, got %d", len(deps.agents.agents))
 	}
 }

--- a/pkg/auth/application/options.go
+++ b/pkg/auth/application/options.go
@@ -46,6 +46,20 @@ func WithEventStore(store esDomain.EventStore) AuthServiceOption {
 	}
 }
 
+// WithEventDispatcher sets an in-process EventDispatcher that receives every
+// committed domain event after the UnitOfWork persists it. Consumers can
+// Subscribe[T] to react to events such as agent.created (e.g., to auto-assign
+// a default role). Dispatch is best-effort: handler errors are non-fatal and
+// do not roll back the auth operation, since the event is already durable.
+// Dispatch only fires when an EventStore is also configured via WithEventStore.
+func WithEventDispatcher(dispatcher *esDomain.EventDispatcher) AuthServiceOption {
+	return func(s *DefaultAuthenticationService) {
+		if dispatcher != nil {
+			s.dispatcher = dispatcher
+		}
+	}
+}
+
 // WithJWTService sets a JWTService for issuing identity tokens.
 // When configured, IssueIdentityToken will produce a signed JWT;
 // otherwise it returns an empty string (opaque-session-only mode).

--- a/pkg/auth/application/password_credential_integration_test.go
+++ b/pkg/auth/application/password_credential_integration_test.go
@@ -7,7 +7,9 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth/application"
@@ -15,6 +17,7 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	gorminfra "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/database/gorm"
 	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
+	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	esinfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
 	"github.com/glebarez/sqlite"
 	"golang.org/x/crypto/bcrypt"
@@ -953,5 +956,66 @@ func TestImportPasswordCredential_DuplicateOnSaveIsIdempotent(t *testing.T) {
 		"$2a$04$abcdefghijklmnopqrstuuwOl4ZJN8xpZ/Hf1jZQp7m/0ePI1ZGGy",
 		owner.GetID(), ownerAccount.GetID()); err != nil {
 		t.Fatalf("ImportPasswordCredential after dup-key race must be idempotent (nil), got %v", err)
+	}
+}
+
+// TestRegisterPassword_DispatchesEventsWhenConfigured covers a second wired
+// commit site (RegisterPassword) so a future refactor reverting `s.dispatcher`
+// to `nil` at any of FindOrCreateAgent / RegisterPassword / Import / Update
+// can be caught by tests of qualitatively different aggregates rather than
+// only the OAuth flow. We assert the password-specific event lands at the
+// dispatcher; the generic Agent/Account/Credential events are already covered
+// by TestFindOrCreateAgent_DispatchesEventsWhenConfigured.
+func TestRegisterPassword_DispatchesEventsWhenConfigured(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gorminfra.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := esinfra.NewGormEventStore(db)
+	if err != nil {
+		t.Fatalf("NewGormEventStore: %v", err)
+	}
+
+	dispatcher := esdomain.NewEventDispatcher()
+
+	var mu sync.Mutex
+	var received []string
+	if err := dispatcher.SubscribeWildcard(func(_ context.Context, env esdomain.EventEnvelope[any]) error {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, env.EventType)
+		return nil
+	}); err != nil {
+		t.Fatalf("SubscribeWildcard: %v", err)
+	}
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		gorminfra.NewAgentRepository(db),
+		gorminfra.NewCredentialRepository(db),
+		gorminfra.NewAuthSessionRepository(db),
+		gorminfra.NewAccountRepository(db),
+		application.WithPasswordCredentialRepository(gorminfra.NewPasswordCredentialRepository(db)),
+		application.WithBcryptCost(bcrypt.MinCost),
+		application.WithEventStore(store),
+		application.WithEventDispatcher(dispatcher),
+	)
+
+	if _, _, _, err := svc.RegisterPassword(ctx, "alice@example.com", "Alice", "hunter2"); err != nil {
+		t.Fatalf("RegisterPassword: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !slices.Contains(received, entities.EventTypePasswordCredentialCreated) {
+		t.Errorf("dispatcher did not receive %q; got %v", entities.EventTypePasswordCredentialCreated, received)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `WithEventDispatcher(*esDomain.EventDispatcher)` functional option to `DefaultAuthenticationService`
- Passes the dispatcher into `NewSimpleUnitOfWork` at all four commit sites — `FindOrCreateAgent`, `RegisterPassword`, `ImportPasswordCredential`, `UpdatePassword`
- Consumers can now `Subscribe[T]` to in-process auth events (e.g., `agent.created` → auto-assign role) without forking pericarp
- Default behavior is unchanged: omit the option and the dispatcher stays `nil`, exactly as before

Closes #33 (epic #32).

## Test plan
- [x] New test: configured dispatcher receives `Agent.Created`, `Account.Created`, `Account.MemberAdded`, and `Credential.Created` from `FindOrCreateAgent`
- [x] New test: omitting `WithEventDispatcher` is a true no-op — `FindOrCreateAgent` succeeds and projections are written
- [x] New test: a handler returning an error does **not** fail the auth operation (matches `SimpleUnitOfWork.Commit`'s eventually-consistent dispatch contract)
- [x] `make lint` — 0 issues
- [x] `make test-unit` — all packages pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)