### PR TITLE
feat(auth): opt-in agent-only fallback for GORM SubscriptionService (#41)

### DIFF
--- a/.claude/journal.md
+++ b/.claude/journal.md
@@ -6,6 +6,16 @@ tasks to maintain context across sessions. Entries are never edited or removed.
 
 ---
 
+### 2026-05-12: Opt-in agent-only fallback for GORM SubscriptionService (#41)
+
+- New `WithGORMAgentFallback() GORMOption` on the GORM subscription adapter. When enabled, an account-scoped lookup that returns `gorm.ErrRecordNotFound` retries against the existing agent-only branch (`account_id = '' OR NULL`). The account-scoped row still wins on a hit (the `err == nil` early-return is unconditional on the flag), and a real DB error on the first query short-circuits before the flag is consulted — the fallback does not mask errors
+- Default behavior is unchanged: the strict `(agent, account)` match documented in `defaultLookup`'s doc comment remains the load-bearing security invariant against the personal→B2B paid-tier leak. Existing `TestGORM_NonEmptyAccountWithNoMatch_ReturnsNil` still pins the strict default by exercising the new `if !g.agentFallback { return nil, nil }` short-circuit
+- Implementation factored the agent-only query into a separate `agentOnlyLookup` helper so the fall-through path and the original `accountID == ""` path share one query body. The `accountID == ""` path is byte-identical to before (same predicate, same NULL handling, same ordering, same error-wrap message)
+- **Why:** Some consumers' subscriptions belong to the human (agent), not to a specific tenant — the agent can be a member of multiple tenant accounts they don't own and the entitlement should follow them across all of them. Before this option, the only escape hatch was `WithGORMResolver`, which forced reimplementing the entire query path (status validation, ordering, NULL handling) just to add one fallback `WHERE`. Strict-by-default is preserved; opt-in shape is the right contract here
+- The same /pr-review hunter that originally caught the cross-tenant leak (see 2026-04-25 entry) signed off on this PR — the fallback can only reach the agent-only row when both the option is on and the account-scoped query returned `ErrRecordNotFound`
+
+---
+
 ### 2026-05-09: Custom JWT claims via ClaimsEnricher (#35)
 
 - `PericarpClaims` (`pkg/auth/application/jwt_service.go`) gained `Extras map[string]any` with custom `MarshalJSON`/`UnmarshalJSON` that flatten extras to top-level JWT claims and re-collect them on parse. Reserved claim names — standard JWT registered (`iss sub aud exp nbf iat jti`) plus pericarp core (`agent_id account_ids active_account_id subscription`) — cannot be smuggled in: `ValidateExtras` rejects them at `IssueToken` time with a wrapped `ErrReservedClaim` listing every offender sorted, and `MarshalJSON` re-runs the same check as a defense-in-depth backstop. `UnmarshalJSON` silently excludes reserved siblings from `Extras` to keep validation tolerant of forged tokens that try to land spoofed core values in the map

--- a/pkg/auth/infrastructure/providers/mastodon.go
+++ b/pkg/auth/infrastructure/providers/mastodon.go
@@ -681,7 +681,6 @@ func (m *Mastodon) fetchUserInfo(ctx context.Context, host, accessToken string) 
 	}, nil
 }
 
-
 // bindFlow stashes a codeChallenge -> host binding with TTL for later retrieval
 // by Exchange. Every gcSweepEvery calls it sweeps expired bindings to bound
 // memory growth from abandoned flows.
@@ -753,4 +752,3 @@ func (m *Mastodon) sweepExpired(now time.Time) {
 		return true
 	})
 }
-

--- a/pkg/auth/infrastructure/providers/netsuite_internal_test.go
+++ b/pkg/auth/infrastructure/providers/netsuite_internal_test.go
@@ -10,11 +10,11 @@ func TestNetSuiteURLBuilders_Derived(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		accountID      string
-		wantToken      string
-		wantRevoke     string
-		wantUserInfo   string
+		name         string
+		accountID    string
+		wantToken    string
+		wantRevoke   string
+		wantUserInfo string
 	}{
 		{
 			name:         "production account",

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -81,7 +81,8 @@ func WithGORMProvider(name string) GORMOption {
 
 // WithGORMAgentFallback enables the default lookup to retry an
 // account-scoped query against the agent-only row (account_id = ''
-// OR NULL) when the (agent_id, accountID) match returns no row.
+// OR account_id IS NULL) when the (agent_id, accountID) match returns
+// no row.
 //
 // Off by default — see the doc on GORM for the cross-tenant leak this
 // guards against. Opt in only when entitlements follow the agent across
@@ -103,13 +104,14 @@ func WithGORMAgentFallback() GORMOption {
 //
 // The default resolver expects a table matching SubscriptionRecord. When
 // accountID is non-empty the lookup requires an exact (agent_id,
-// account_id) match — the agent-only row is NOT used as a fallback,
-// because a paid personal-account subscription must not silently grant
-// paid-tier access to a B2B account the same agent belongs to. When
-// accountID is empty, the agent-only row (account_id = '' or IS NULL)
-// is matched. Among matches, latest updated_at wins; ties break on the
-// row's primary key id so output is deterministic. For schemas that
-// don't fit that shape, supply WithGORMResolver.
+// account_id) match — by default the agent-only row is NOT used as a
+// fallback, because a paid personal-account subscription must not
+// silently grant paid-tier access to a B2B account the same agent
+// belongs to. When accountID is empty, the agent-only row
+// (account_id = '' OR account_id IS NULL) is matched. Among matches,
+// latest updated_at wins; ties break on the row's primary key id so
+// output is deterministic. For schemas that don't fit that shape,
+// supply WithGORMResolver.
 //
 // Consumers whose entitlements follow the human across every tenant they
 // belong to (rather than being scoped to a specific tenant they own) can

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -19,12 +19,12 @@ const (
 // AutoMigrate this struct into their schema or override the table name via
 // WithGORMTable; for fully custom schemas use WithGORMResolver.
 type SubscriptionRecord struct {
-	ID        uint       `gorm:"primaryKey"`
-	AgentID   string     `gorm:"size:512;index:idx_sub_agent_account,priority:1;not null"`
-	AccountID string     `gorm:"size:512;index:idx_sub_agent_account,priority:2"`
-	Status    string     `gorm:"size:32;not null"`
-	Plan      string     `gorm:"size:128"`
-	Provider  string     `gorm:"size:64"`
+	ID        uint   `gorm:"primaryKey"`
+	AgentID   string `gorm:"size:512;index:idx_sub_agent_account,priority:1;not null"`
+	AccountID string `gorm:"size:512;index:idx_sub_agent_account,priority:2"`
+	Status    string `gorm:"size:32;not null"`
+	Plan      string `gorm:"size:128"`
+	Provider  string `gorm:"size:64"`
 	ExpiresAt *time.Time
 	UpdatedAt time.Time
 }
@@ -79,6 +79,23 @@ func WithGORMProvider(name string) GORMOption {
 	}
 }
 
+// WithGORMAgentFallback enables the default lookup to retry an
+// account-scoped query against the agent-only row (account_id = ”
+// OR NULL) when the (agent_id, accountID) match returns no row.
+//
+// Off by default — see the doc on GORM for the cross-tenant leak this
+// guards against. Opt in only when entitlements follow the agent across
+// every tenant context they're enrolled in (the subscription belongs to
+// the human, not to a specific tenant they're a member of).
+//
+// When enabled, an account-scoped row still wins over the agent-only row
+// — the fallback only runs when the account-scoped query returns no row.
+func WithGORMAgentFallback() GORMOption {
+	return func(g *GORM) {
+		g.agentFallback = true
+	}
+}
+
 // GORM resolves SubscriptionClaim values from a relational projection
 // owned by the consumer service. Implements application.SubscriptionService.
 //
@@ -87,15 +104,20 @@ func WithGORMProvider(name string) GORMOption {
 // account_id) match — the agent-only row is NOT used as a fallback,
 // because a paid personal-account subscription must not silently grant
 // paid-tier access to a B2B account the same agent belongs to. When
-// accountID is empty, the agent-only row (account_id = '' or IS NULL)
+// accountID is empty, the agent-only row (account_id = ” or IS NULL)
 // is matched. Among matches, latest updated_at wins; ties break on the
 // row's primary key id so output is deterministic. For schemas that
 // don't fit that shape, supply WithGORMResolver.
+//
+// Consumers whose entitlements follow the human across every tenant they
+// belong to (rather than being scoped to a specific tenant they own) can
+// opt into an agent-only fallback via WithGORMAgentFallback.
 type GORM struct {
 	db               *gorm.DB
 	table            string
 	resolver         Resolver
 	providerFallback string
+	agentFallback    bool
 }
 
 // NewGORM returns a GORM adapter backed by db. The default lookup queries
@@ -145,24 +167,36 @@ func (g *GORM) GetSubscription(ctx context.Context, agentID, accountID string) (
 }
 
 func (g *GORM) defaultLookup(ctx context.Context, agentID, accountID string) (*auth.SubscriptionClaim, error) {
-	var rec SubscriptionRecord
-	base := g.db.WithContext(ctx).Table(g.table).Where("agent_id = ?", agentID)
-
 	if accountID != "" {
-		err := base.Where("account_id = ?", accountID).
+		var rec SubscriptionRecord
+		err := g.db.WithContext(ctx).Table(g.table).
+			Where("agent_id = ?", agentID).
+			Where("account_id = ?", accountID).
 			Order("updated_at DESC, id DESC").
 			Limit(1).
 			Take(&rec).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
+		if err == nil {
+			return g.toClaim(rec), nil
 		}
-		if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("gorm: query account-scoped subscription: %w", err)
 		}
-		return g.toClaim(rec), nil
+		if !g.agentFallback {
+			return nil, nil
+		}
+		// Fall through to the agent-only lookup. Only reached when the
+		// account-scoped query returned no row AND WithGORMAgentFallback
+		// was enabled, so the account-scoped row still wins on a hit.
 	}
 
-	err := base.Where("(account_id = ? OR account_id IS NULL)", "").
+	return g.agentOnlyLookup(ctx, agentID)
+}
+
+func (g *GORM) agentOnlyLookup(ctx context.Context, agentID string) (*auth.SubscriptionClaim, error) {
+	var rec SubscriptionRecord
+	err := g.db.WithContext(ctx).Table(g.table).
+		Where("agent_id = ?", agentID).
+		Where("(account_id = ? OR account_id IS NULL)", "").
 		Order("updated_at DESC, id DESC").
 		Limit(1).
 		Take(&rec).Error

--- a/pkg/auth/infrastructure/subscription/gorm.go
+++ b/pkg/auth/infrastructure/subscription/gorm.go
@@ -80,7 +80,7 @@ func WithGORMProvider(name string) GORMOption {
 }
 
 // WithGORMAgentFallback enables the default lookup to retry an
-// account-scoped query against the agent-only row (account_id = ”
+// account-scoped query against the agent-only row (account_id = ''
 // OR NULL) when the (agent_id, accountID) match returns no row.
 //
 // Off by default — see the doc on GORM for the cross-tenant leak this
@@ -90,6 +90,8 @@ func WithGORMProvider(name string) GORMOption {
 //
 // When enabled, an account-scoped row still wins over the agent-only row
 // — the fallback only runs when the account-scoped query returns no row.
+// Database errors on the account-scoped query are propagated as-is; only
+// gorm.ErrRecordNotFound triggers the fallback.
 func WithGORMAgentFallback() GORMOption {
 	return func(g *GORM) {
 		g.agentFallback = true
@@ -104,7 +106,7 @@ func WithGORMAgentFallback() GORMOption {
 // account_id) match — the agent-only row is NOT used as a fallback,
 // because a paid personal-account subscription must not silently grant
 // paid-tier access to a B2B account the same agent belongs to. When
-// accountID is empty, the agent-only row (account_id = ” or IS NULL)
+// accountID is empty, the agent-only row (account_id = '' or IS NULL)
 // is matched. Among matches, latest updated_at wins; ties break on the
 // row's primary key id so output is deterministic. For schemas that
 // don't fit that shape, supply WithGORMResolver.

--- a/pkg/auth/infrastructure/subscription/gorm_test.go
+++ b/pkg/auth/infrastructure/subscription/gorm_test.go
@@ -226,6 +226,58 @@ func TestGORM_AgentFallback_AccountHitStillWins(t *testing.T) {
 	}
 }
 
+func TestGORM_AgentFallback_NullAccountIDRowMatched(t *testing.T) {
+	// Schemas that store the agent-only row with account_id = NULL
+	// (rather than '') must satisfy the fallback path — that schema
+	// shape is one of the motivating use cases for the option. Seed
+	// via raw SQL because the default *string SubscriptionRecord
+	// schema writes "" for the zero value.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	if err := db.Exec(
+		"INSERT INTO subscriptions (agent_id, account_id, status, plan, updated_at) VALUES (?, NULL, ?, ?, ?)",
+		"agent-1", "active", "personal", time.Now(),
+	).Error; err != nil {
+		t.Fatalf("seed via raw SQL: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected fallback claim for NULL account_id row, got nil")
+	}
+	if claim.Plan != "personal" {
+		t.Errorf("Plan = %q, want personal", claim.Plan)
+	}
+}
+
+func TestGORM_AgentFallback_DBErrorOnFallbackQuery_Propagates(t *testing.T) {
+	// With fallback enabled and the account-scoped query missing, the
+	// second (agent-only) query runs. A DB error there must propagate
+	// — silently swallowing it would mask connectivity / timeout
+	// failures and leave the caller unable to distinguish "no record"
+	// from "lookup failed."
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get *sql.DB: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close DB: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
+	if _, err := g.GetSubscription(context.Background(), "agent-1", "team-1"); err == nil {
+		t.Fatal("expected error from closed DB, got nil")
+	}
+}
+
 func TestGORM_AgentFallback_BothMissReturnsNil(t *testing.T) {
 	// Fallback enabled but neither the account-scoped row nor an
 	// agent-only row exists. Must return (nil, nil) — the option must

--- a/pkg/auth/infrastructure/subscription/gorm_test.go
+++ b/pkg/auth/infrastructure/subscription/gorm_test.go
@@ -155,9 +155,10 @@ func TestGORM_NonEmptyAccountWithNoMatch_ReturnsNil(t *testing.T) {
 }
 
 func TestGORM_AgentFallback_AccountMissReturnsAgentOnlyRow(t *testing.T) {
-	// With WithGORMAgentFallback, an account-scoped miss falls back to
-	// the agent-only row — for consumers whose entitlement follows the
-	// human across every tenant they're enrolled in.
+	// When the WithGORMAgentFallback option is enabled, an account-scoped
+	// miss falls back to the agent-only row — for consumers whose
+	// entitlement follows the human across every tenant they're enrolled
+	// in.
 	t.Parallel()
 
 	db := newGormTestDB(t)
@@ -261,6 +262,12 @@ func TestGORM_AgentFallback_DBErrorOnFallbackQuery_Propagates(t *testing.T) {
 	// — silently swallowing it would mask connectivity / timeout
 	// failures and leave the caller unable to distinguish "no record"
 	// from "lookup failed."
+	//
+	// Setup: register an After("gorm:query") callback that drops the
+	// subscriptions table once the first SELECT (account-scoped, will
+	// return ErrRecordNotFound on the empty table) completes. The
+	// fallback's agent-only SELECT then runs against a now-missing
+	// table and surfaces a SQL error from the driver.
 	t.Parallel()
 
 	db := newGormTestDB(t)
@@ -268,13 +275,26 @@ func TestGORM_AgentFallback_DBErrorOnFallbackQuery_Propagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get *sql.DB: %v", err)
 	}
-	if err := sqlDB.Close(); err != nil {
-		t.Fatalf("close DB: %v", err)
+
+	queryCount := 0
+	if err := db.Callback().Query().After("gorm:query").Register("test:drop_table_after_first_select", func(tx *gorm.DB) {
+		queryCount++
+		if queryCount == 1 {
+			if _, err := sqlDB.Exec("DROP TABLE subscriptions"); err != nil {
+				t.Errorf("drop subscriptions table: %v", err)
+			}
+		}
+	}); err != nil {
+		t.Fatalf("register callback: %v", err)
 	}
 
 	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
-	if _, err := g.GetSubscription(context.Background(), "agent-1", "team-1"); err == nil {
-		t.Fatal("expected error from closed DB, got nil")
+	_, err = g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err == nil {
+		t.Fatal("expected error from agent-only fallback query failure, got nil")
+	}
+	if queryCount != 2 {
+		t.Errorf("queryCount = %d, want 2 (account-scoped + agent-only fallback)", queryCount)
 	}
 }
 

--- a/pkg/auth/infrastructure/subscription/gorm_test.go
+++ b/pkg/auth/infrastructure/subscription/gorm_test.go
@@ -154,6 +154,103 @@ func TestGORM_NonEmptyAccountWithNoMatch_ReturnsNil(t *testing.T) {
 	}
 }
 
+func TestGORM_AgentFallback_AccountMissReturnsAgentOnlyRow(t *testing.T) {
+	// With WithGORMAgentFallback, an account-scoped miss falls back to
+	// the agent-only row — for consumers whose entitlement follows the
+	// human across every tenant they're enrolled in.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-1", AccountID: "",
+		Status: string(auth.SubscriptionStatusActive), Plan: "personal",
+		UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected fallback claim, got nil")
+	}
+	if claim.Plan != "personal" {
+		t.Errorf("Plan = %q, want personal (agent-only fallback row)", claim.Plan)
+	}
+	if claim.Status != auth.SubscriptionStatusActive {
+		t.Errorf("Status = %q, want active", claim.Status)
+	}
+}
+
+func TestGORM_AgentFallback_AccountHitStillWins(t *testing.T) {
+	// The fallback only runs on miss — when an account-scoped row
+	// exists, it wins over the agent-only row. Otherwise enabling the
+	// option would silently demote a tenant-specific entitlement to the
+	// agent's personal row, which is the opposite of the intent.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	now := time.Now()
+	rows := []*subscription.SubscriptionRecord{
+		{
+			AgentID: "agent-1", AccountID: "",
+			Status: string(auth.SubscriptionStatusActive), Plan: "personal",
+			UpdatedAt: now,
+		},
+		{
+			AgentID: "agent-1", AccountID: "team-1",
+			Status: string(auth.SubscriptionStatusInactive), Plan: "team_free",
+			UpdatedAt: now.Add(-time.Hour),
+		},
+	}
+	for _, r := range rows {
+		if err := db.Create(r).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected claim, got nil")
+	}
+	if claim.Plan != "team_free" {
+		t.Errorf("Plan = %q, want team_free (account-scoped row must win even with fallback enabled)", claim.Plan)
+	}
+}
+
+func TestGORM_AgentFallback_BothMissReturnsNil(t *testing.T) {
+	// Fallback enabled but neither the account-scoped row nor an
+	// agent-only row exists. Must return (nil, nil) — the option must
+	// not turn "no record" into a synthesized claim.
+	t.Parallel()
+
+	db := newGormTestDB(t)
+	row := &subscription.SubscriptionRecord{
+		AgentID: "agent-other", AccountID: "team-1",
+		Status: "active", Plan: "pro", UpdatedAt: time.Now(),
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	g := subscription.NewGORM(db, subscription.WithGORMAgentFallback())
+	claim, err := g.GetSubscription(context.Background(), "agent-1", "team-1")
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("expected nil claim, got %+v", claim)
+	}
+}
+
 func TestGORM_LatestUpdatedAtWins(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/infrastructure/subscription/stripe.go
+++ b/pkg/auth/infrastructure/subscription/stripe.go
@@ -204,9 +204,9 @@ func (s *Stripe) GetSubscription(ctx context.Context, agentID, accountID string)
 // further ties broken by subscription ID for stable output.
 func (s *Stripe) toClaim(search stripeCustomerSearch) *auth.SubscriptionClaim {
 	var (
-		best        *stripeSubscription
-		bestCust    string
-		matchCount  int
+		best       *stripeSubscription
+		bestCust   string
+		matchCount int
 	)
 	for i := range search.Data {
 		for j := range search.Data[i].Subscriptions.Data {

--- a/pkg/auth/infrastructure/subscription/stripe_test.go
+++ b/pkg/auth/infrastructure/subscription/stripe_test.go
@@ -678,4 +678,3 @@ func TestStripe_WithHTTPClient_NilNoOp(t *testing.T) {
 		t.Fatalf("GetSubscription error: %v", err)
 	}
 }
-


### PR DESCRIPTION
## Summary

Closes #41. Adds a new `WithGORMAgentFallback() GORMOption` so consumers whose entitlements follow the human (agent) across every tenant they belong to can opt into a fallback from an account-scoped miss to the agent-only row (`account_id = '' OR NULL`).

- **Default behavior unchanged**: account-scoped lookups still require an exact `(agent_id, account_id)` match. The strict default guards against the documented cross-tenant leak (a paid personal-account subscription silently granting paid-tier access to a B2B account the agent belongs to).
- **Account-scoped hit still wins** over the agent-only row when the option is enabled — the fallback only runs on `gorm.ErrRecordNotFound`.
- **DB errors are propagated**, never masked by the fallback retry. The `errors.Is(err, gorm.ErrRecordNotFound)` check is ordered before the option flag check.

Refactor extracts the agent-only query into an `agentOnlyLookup` helper so the fall-through path and the original `accountID == ""` path share one query body. The empty-`accountID` path is byte-identical to before.

## Test plan

- [x] `make lint` clean
- [x] `go test -race ./pkg/auth/infrastructure/subscription/` — all 5 fallback tests pass alongside the existing suite
- [x] Existing `TestGORM_NonEmptyAccountWithNoMatch_ReturnsNil` still pins the strict-default invariant (now exercises the new `if !g.agentFallback { return nil, nil }` short-circuit)
- [x] New `TestGORM_AgentFallback_AccountMissReturnsAgentOnlyRow` — fallback returns the agent-only row on account miss
- [x] New `TestGORM_AgentFallback_AccountHitStillWins` — account-scoped row wins even when fallback is enabled and the agent-only row is newer
- [x] New `TestGORM_AgentFallback_BothMissReturnsNil` — option does not synthesize a claim when nothing matches
- [x] New `TestGORM_AgentFallback_NullAccountIDRowMatched` — schemas storing `account_id = NULL` reach the fallback path
- [x] New `TestGORM_AgentFallback_DBErrorOnFallbackQuery_Propagates` — DB error on the fallback's agent-only query surfaces to the caller

## Review

Ran `/pr-review` against the diff before opening:

- code-reviewer: no findings ≥ 80 confidence
- silent-failure-hunter: clean — strict default holds, account hit always wins, DB errors never masked, status validation still runs on fallback row
- pr-test-analyzer: flagged the NULL-row and DB-error fall-through gaps — added tests above
- comment-analyzer: flagged Unicode `”` substituted for `''` in two doc comments and asked for a DB-error clarification on `WithGORMAgentFallback` — both fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)