### PR TITLE
Epic #45: event store concurrency fixes + deterministic subscription tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       
       - name: Run tests
         run: make test
+        env:
+          # Docker is available on ubuntu-latest; refuse to silently skip
+          # the container-backed DynamoDB regression tests.
+          PERICARP_REQUIRE_DOCKER_TESTS: "1"
       
       - name: Run linter
         uses: golangci/golangci-lint-action@v7

--- a/pkg/auth/infrastructure/subscription/revenuecat_test.go
+++ b/pkg/auth/infrastructure/subscription/revenuecat_test.go
@@ -52,15 +52,17 @@ func TestRevenueCat_NoEntitlements_ReturnsNil(t *testing.T) {
 func TestRevenueCat_ActiveEntitlement(t *testing.T) {
 	t.Parallel()
 
-	// This test asserts claim.IsActive(), which consults the real wall clock
-	// (time.Now()) by design — it is the production "is this still valid right
-	// now?" predicate. So the expiry must be anchored to real time, not a
-	// frozen date: a hardcoded past date made the test a time-bomb that
-	// silently started failing once wall-clock now passed the fixed expiry.
-	// Truncating to whole seconds keeps the RFC3339 round-trip exact for the
-	// ExpiresAt.Equal assertion below. The injected adapter clock is set to the
-	// same now so status computation stays consistent with IsActive.
-	now := time.Now().UTC().Truncate(time.Second)
+	// Activity is asserted via IsActiveAt(now) against the same frozen
+	// instant injected into the adapter — never via IsActive(), which reads
+	// the real wall clock. Pairing IsActive() with a frozen fixture date
+	// once made this test a time-bomb that started failing when wall-clock
+	// now passed the fixed expiry; anchoring the fixture on time.Now()
+	// avoided that but left the assertion wall-clock-dependent. A frozen
+	// date plus IsActiveAt keeps every input deterministic. Keep the
+	// fixture on whole seconds: expires round-trips through RFC3339, which
+	// drops sub-second precision, and the ExpiresAt.Equal assertion below
+	// requires an exact match.
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	expires := now.Add(30 * 24 * time.Hour)
 	body := `{
 		"subscriber": {
@@ -114,8 +116,8 @@ func TestRevenueCat_ActiveEntitlement(t *testing.T) {
 	if got := claim.Metadata["store"]; got != "app_store" {
 		t.Errorf("Metadata[store] = %v, want app_store", got)
 	}
-	if !claim.IsActive() {
-		t.Error("IsActive() = false, want true")
+	if !claim.IsActiveAt(now) {
+		t.Error("IsActiveAt(now) = false, want true")
 	}
 }
 
@@ -205,8 +207,8 @@ func TestRevenueCat_ExpiredEntitlement_MarkedInactive(t *testing.T) {
 	if claim.Status != auth.SubscriptionStatusInactive {
 		t.Errorf("Status = %q, want %q", claim.Status, auth.SubscriptionStatusInactive)
 	}
-	if claim.IsActive() {
-		t.Error("IsActive() = true, want false for expired entitlement")
+	if claim.IsActiveAt(now) {
+		t.Error("IsActiveAt(now) = true, want false for expired entitlement")
 	}
 }
 
@@ -376,8 +378,8 @@ func TestRevenueCat_LifetimeRevoked_MarkedInactive(t *testing.T) {
 	if claim.Status != auth.SubscriptionStatusInactive {
 		t.Errorf("Status = %q, want %q for revoked lifetime", claim.Status, auth.SubscriptionStatusInactive)
 	}
-	if claim.IsActive() {
-		t.Error("IsActive() = true, want false for revoked lifetime")
+	if claim.IsActiveAt(now) {
+		t.Error("IsActiveAt(now) = true, want false for revoked lifetime")
 	}
 }
 

--- a/pkg/auth/infrastructure/subscription/stripe_test.go
+++ b/pkg/auth/infrastructure/subscription/stripe_test.go
@@ -476,15 +476,16 @@ func TestStripe_WithHTTPClient_UsesProvidedClient(t *testing.T) {
 func TestStripe_CanceledButStillInPaidWindow_StaysActive(t *testing.T) {
 	// Stripe flips status to "canceled" the moment the merchant cancels
 	// even though current_period_end is still in the future and the
-	// customer is entitled to access through that date. Adapter must
-	// keep IsActive() = true and surface the cancellation in metadata.
+	// customer is entitled to access through that date. Adapter must keep
+	// the claim active within the paid window (asserted via IsActiveAt
+	// below) and surface the cancellation in metadata.
 	t.Parallel()
 
-	// Anchor on wall-clock time. SubscriptionClaim.IsActive() reads
-	// time.Now() directly (not the injected clock), so a hardcoded date
-	// would silently drift and start failing once wall-clock advances
-	// past periodEnd.
-	now := time.Now().UTC()
+	// Activity is asserted via IsActiveAt(now) against the same frozen
+	// instant injected into the adapter — IsActive() reads the real wall
+	// clock, and pairing it with a fixed date would silently start failing
+	// once wall-clock now passed periodEnd.
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	periodEnd := now.Add(7 * 24 * time.Hour).Unix()
 	body := stripeFixture(stripeSub("sub_1", "canceled", periodEnd, "pro", false))
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -503,8 +504,8 @@ func TestStripe_CanceledButStillInPaidWindow_StaysActive(t *testing.T) {
 	if claim.Status != auth.SubscriptionStatusActive {
 		t.Errorf("Status = %q, want Active while still in paid window", claim.Status)
 	}
-	if !claim.IsActive() {
-		t.Error("IsActive() = false, want true")
+	if !claim.IsActiveAt(now) {
+		t.Error("IsActiveAt(now) = false, want true")
 	}
 	if got := claim.Metadata["cancel_at_period_end"]; got != true {
 		t.Errorf("cancel_at_period_end metadata = %v, want true", got)

--- a/pkg/auth/subscription.go
+++ b/pkg/auth/subscription.go
@@ -51,17 +51,27 @@ type SubscriptionClaim struct {
 	Metadata  map[string]any `json:"metadata,omitempty"`
 }
 
-// IsActive reports whether the subscription should grant paid-tier access.
-// Returns false for a nil receiver, for any non-active/trialing status, and
-// for an explicit ExpiresAt in the past — that last guard means a stale
-// snapshot held across an account-switch (which preserves the claim
-// verbatim) cannot grant access beyond the provider-attested expiry. A
-// zero ExpiresAt is treated as "no expiry expressed" and ignored.
+// IsActive reports whether the subscription should grant paid-tier access
+// right now. It is IsActiveAt evaluated at time.Now(); see IsActiveAt for
+// the actual rules.
 func (s *SubscriptionClaim) IsActive() bool {
+	return s.IsActiveAt(time.Now())
+}
+
+// IsActiveAt reports whether the subscription should grant paid-tier access
+// at the given instant. Returns false for a nil receiver, for any
+// non-active/trialing status, and for an explicit ExpiresAt strictly before
+// now — that last guard means a stale snapshot held across an
+// account-switch (which preserves the claim verbatim) cannot grant access
+// beyond the provider-attested expiry. A zero ExpiresAt is treated as "no
+// expiry expressed" and ignored. Tests and any caller with an injected
+// clock should use this instead of IsActive so the result does not depend
+// on the wall clock.
+func (s *SubscriptionClaim) IsActiveAt(now time.Time) bool {
 	if s == nil {
 		return false
 	}
-	if !s.ExpiresAt.IsZero() && time.Now().After(s.ExpiresAt) {
+	if !s.ExpiresAt.IsZero() && now.After(s.ExpiresAt) {
 		return false
 	}
 	switch s.Status {

--- a/pkg/auth/subscription_test.go
+++ b/pkg/auth/subscription_test.go
@@ -40,6 +40,36 @@ func TestSubscriptionClaim_IsActive(t *testing.T) {
 	}
 }
 
+func TestSubscriptionClaim_IsActiveAt(t *testing.T) {
+	t.Parallel()
+
+	// Fixed reference instant — every input is deterministic, no wall clock.
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		claim  *SubscriptionClaim
+		active bool
+	}{
+		{name: "nil claim", claim: nil, active: false},
+		{name: "active no expiry", claim: &SubscriptionClaim{Status: SubscriptionStatusActive}, active: true},
+		{name: "active expires future", claim: &SubscriptionClaim{Status: SubscriptionStatusActive, ExpiresAt: now.Add(time.Hour)}, active: true},
+		{name: "active expires exactly now", claim: &SubscriptionClaim{Status: SubscriptionStatusActive, ExpiresAt: now}, active: true},
+		{name: "active expired", claim: &SubscriptionClaim{Status: SubscriptionStatusActive, ExpiresAt: now.Add(-time.Second)}, active: false},
+		{name: "trialing expired", claim: &SubscriptionClaim{Status: SubscriptionStatusTrialing, ExpiresAt: now.Add(-time.Hour)}, active: false},
+		{name: "cancelled expires future", claim: &SubscriptionClaim{Status: SubscriptionStatusCancelled, ExpiresAt: now.Add(time.Hour)}, active: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.claim.IsActiveAt(now); got != tc.active {
+				t.Errorf("IsActiveAt(now) = %v, want %v", got, tc.active)
+			}
+		})
+	}
+}
+
 func TestSubscriptionStatus_Valid(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/eventsourcing/infrastructure/dynamo_store.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store.go
@@ -47,6 +47,9 @@ func NewDynamoEventStore(client *dynamodb.Client, tableName string) *DynamoEvent
 
 // Append appends events to the store for the given aggregate.
 // If expectedVersion is not -1, optimistic concurrency control is enforced.
+// expectedVersion == -1 skips the version check but still refuses to
+// overwrite: appending an event whose (aggregate_id, sequence_no) is
+// already stored fails with ErrConcurrencyConflict.
 func (s *DynamoEventStore) Append(ctx context.Context, aggregateID string, expectedVersion int, events ...domain.EventEnvelope[any]) error {
 	if len(events) == 0 {
 		return nil
@@ -66,7 +69,7 @@ func (s *DynamoEventStore) Append(ctx context.Context, aggregateID string, expec
 			return fmt.Errorf("%w: batch size %d exceeds DynamoDB limit of %d",
 				domain.ErrInvalidEvent, len(events), dynamoMaxTransactItems)
 		}
-		return s.appendWithoutVersionCheck(ctx, events)
+		return s.appendWithoutVersionCheck(ctx, aggregateID, events)
 	}
 
 	// Reserve 1 slot for the ConditionCheck item used in version verification
@@ -79,42 +82,27 @@ func (s *DynamoEventStore) Append(ctx context.Context, aggregateID string, expec
 	return s.appendWithVersionCheck(ctx, aggregateID, expectedVersion, events)
 }
 
-func (s *DynamoEventStore) appendWithoutVersionCheck(ctx context.Context, events []domain.EventEnvelope[any]) error {
-	// Use BatchWriteItem for batches of up to 25 items
-	const batchLimit = 25
-	for i := 0; i < len(events); i += batchLimit {
-		end := min(i+batchLimit, len(events))
-		batch := events[i:end]
-
-		writeRequests := make([]types.WriteRequest, len(batch))
-		for j, event := range batch {
-			item, err := envelopeToDynamoItem(event)
-			if err != nil {
-				return fmt.Errorf("%w: %v", domain.ErrInvalidEvent, err)
-			}
-			writeRequests[j] = types.WriteRequest{
-				PutRequest: &types.PutRequest{Item: item},
-			}
-		}
-
-		result, err := s.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-			RequestItems: map[string][]types.WriteRequest{
-				s.tableName: writeRequests,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to batch write events: %w", err)
-		}
-		if len(result.UnprocessedItems) > 0 {
-			return fmt.Errorf("failed to write all events: %d items were not processed by DynamoDB",
-				len(result.UnprocessedItems[s.tableName]))
-		}
+// appendWithoutVersionCheck writes events without verifying the aggregate's
+// current version, but still refuses to overwrite: every Put carries
+// attribute_not_exists, so an event whose (aggregate_id, sequence_no)
+// already exists fails the whole transaction with ErrConcurrencyConflict.
+// A previous implementation used BatchWriteItem, whose PutRequests silently
+// REPLACE existing items — appending a duplicate sequence number destroyed
+// the stored event with no error — and which could partially persist
+// earlier batches before reporting unprocessed items. TransactWriteItems is
+// all-or-nothing, and the -1 path is capped at dynamoMaxTransactItems in
+// Append, so a single transaction always suffices.
+func (s *DynamoEventStore) appendWithoutVersionCheck(ctx context.Context, aggregateID string, events []domain.EventEnvelope[any]) error {
+	transactItems, err := s.eventPutItems(events)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	// putOffset 0: every transact item is an event Put.
+	return s.transactWriteEvents(ctx, aggregateID, transactItems, events, 0, "")
 }
 
 func (s *DynamoEventStore) appendWithVersionCheck(ctx context.Context, aggregateID string, expectedVersion int, events []domain.EventEnvelope[any]) error {
-	// Build Put items for each event with attribute_not_exists to prevent duplicate (aggregate_id, sequence_no)
 	transactItems := make([]types.TransactWriteItem, 0, len(events)+1)
 
 	// Add an atomic ConditionCheck to verify the expected version exists.
@@ -133,10 +121,31 @@ func (s *DynamoEventStore) appendWithVersionCheck(ctx context.Context, aggregate
 		})
 	}
 
+	putItems, err := s.eventPutItems(events)
+	if err != nil {
+		return err
+	}
+	transactItems = append(transactItems, putItems...)
+
+	// putOffset 1 when a ConditionCheck item precedes the event Puts, so a
+	// cancellation reason index maps back to the right event.
+	putOffset := 0
+	if expectedVersion > 0 {
+		putOffset = 1
+	}
+	return s.transactWriteEvents(ctx, aggregateID, transactItems, events, putOffset,
+		fmt.Sprintf("expected version %d", expectedVersion))
+}
+
+// eventPutItems converts events to transactional Put items, each guarded by
+// attribute_not_exists to prevent overwriting a stored (aggregate_id,
+// sequence_no) item.
+func (s *DynamoEventStore) eventPutItems(events []domain.EventEnvelope[any]) ([]types.TransactWriteItem, error) {
+	transactItems := make([]types.TransactWriteItem, 0, len(events))
 	for _, event := range events {
 		item, err := envelopeToDynamoItem(event)
 		if err != nil {
-			return fmt.Errorf("%w: %v", domain.ErrInvalidEvent, err)
+			return nil, fmt.Errorf("%w: %v", domain.ErrInvalidEvent, err)
 		}
 		transactItems = append(transactItems, types.TransactWriteItem{
 			Put: &types.Put{
@@ -146,17 +155,47 @@ func (s *DynamoEventStore) appendWithVersionCheck(ctx context.Context, aggregate
 			},
 		})
 	}
+	return transactItems, nil
+}
 
+// transactWriteEvents executes the transaction and maps conflict-class
+// cancellations to ErrConcurrencyConflict. CancellationReasons map
+// index-for-index onto transactItems, and event Puts start at putOffset
+// (1 when a version ConditionCheck precedes them, else 0), so a failed
+// condition can name the exact cause: versionDetail when the version
+// ConditionCheck itself failed, or the colliding event's sequence number
+// when a Put hit an already-stored (aggregate_id, sequence_no) item.
+// A TransactionConflict reason (another in-flight transaction touched the
+// same items) is also mapped to ErrConcurrencyConflict: it is a transient
+// concurrency failure and retrying — the standard caller response to the
+// sentinel — is the correct treatment.
+func (s *DynamoEventStore) transactWriteEvents(ctx context.Context, aggregateID string, transactItems []types.TransactWriteItem, events []domain.EventEnvelope[any], putOffset int, versionDetail string) error {
 	_, err := s.client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
 		TransactItems: transactItems,
 	})
 	if err != nil {
 		var txCancelled *types.TransactionCanceledException
 		if errors.As(err, &txCancelled) {
+			for i, reason := range txCancelled.CancellationReasons {
+				if reason.Code == nil || *reason.Code != "ConditionalCheckFailed" {
+					continue
+				}
+				if i < putOffset {
+					// The version ConditionCheck item failed.
+					return fmt.Errorf("%w: %s for aggregate %s",
+						domain.ErrConcurrencyConflict, versionDetail, aggregateID)
+				}
+				if evIdx := i - putOffset; evIdx < len(events) {
+					return fmt.Errorf("%w: sequence number %d already stored for aggregate %s",
+						domain.ErrConcurrencyConflict, events[evIdx].SequenceNo, aggregateID)
+				}
+				return fmt.Errorf("%w: conditional check failed for aggregate %s",
+					domain.ErrConcurrencyConflict, aggregateID)
+			}
 			for _, reason := range txCancelled.CancellationReasons {
-				if reason.Code != nil && *reason.Code == "ConditionalCheckFailed" {
-					return fmt.Errorf("%w: expected version %d",
-						domain.ErrConcurrencyConflict, expectedVersion)
+				if reason.Code != nil && *reason.Code == "TransactionConflict" {
+					return fmt.Errorf("%w: concurrent transaction in flight for aggregate %s (transient, safe to retry)",
+						domain.ErrConcurrencyConflict, aggregateID)
 				}
 			}
 			// Not a concurrency conflict — surface the actual transaction cancellation

--- a/pkg/eventsourcing/infrastructure/dynamo_store_test.go
+++ b/pkg/eventsourcing/infrastructure/dynamo_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -156,6 +157,12 @@ func setupDynamoStore(t *testing.T) domain.EventStore {
 
 	endpoint, err := startDynamoContainer(t)
 	if err != nil {
+		// In CI the DynamoDB tests are load-bearing (they pin the
+		// no-overwrite contract), so a container hiccup must fail loudly
+		// instead of turning the whole suite into a green skip.
+		if os.Getenv("PERICARP_REQUIRE_DOCKER_TESTS") != "" {
+			t.Fatalf("PERICARP_REQUIRE_DOCKER_TESTS is set but the DynamoDB container failed to start: %v", err)
+		}
 		t.Skipf("skipping DynamoDB test: %v (Docker may not be available)", err)
 	}
 
@@ -585,6 +592,92 @@ func TestDynamoStore_GetEventsRange(t *testing.T) {
 		}
 		if len(allFromVersion2) != 3 {
 			t.Fatalf("expected 3 events from version 2 onwards, got %d", len(allFromVersion2))
+		}
+	})
+}
+
+// TestDynamoStore_NoVersionCheck_NeverOverwrites pins the contract that the
+// expectedVersion == -1 path refuses to overwrite a stored event. The
+// previous BatchWriteItem implementation silently REPLACED items with the
+// same (aggregate_id, sequence_no) — destroying the stored event with no
+// error — and could leave earlier batches persisted when a later batch
+// failed. The conditional TransactWriteItems implementation must reject the
+// whole append with ErrConcurrencyConflict and leave the stored events
+// untouched.
+func TestDynamoStore_NoVersionCheck_NeverOverwrites(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate sequence is rejected and original survives", func(t *testing.T) {
+		t.Parallel()
+
+		store := setupDynamoStore(t)
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+		aggregateID := "no-overwrite-aggregate"
+
+		original := createTestEvent(aggregateID, "original-event", "test.created", 1)
+		if err := store.Append(ctx, aggregateID, -1, original); err != nil {
+			t.Fatalf("failed to append original event: %v", err)
+		}
+
+		imposter := createTestEvent(aggregateID, "imposter-event", "test.overwritten", 1)
+		err := store.Append(ctx, aggregateID, -1, imposter)
+		if err == nil {
+			t.Fatal("expected error appending duplicate sequence number, got nil")
+		}
+		if !errors.Is(err, domain.ErrConcurrencyConflict) {
+			t.Fatalf("error = %v, want errors.Is(err, ErrConcurrencyConflict)", err)
+		}
+
+		events, err := store.GetEvents(ctx, aggregateID)
+		if err != nil {
+			t.Fatalf("failed to get events: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(events))
+		}
+		if events[0].ID != "original-event" {
+			t.Errorf("stored event ID = %q, want original-event (original was overwritten)", events[0].ID)
+		}
+		if events[0].EventType != "test.created" {
+			t.Errorf("stored event type = %q, want test.created", events[0].EventType)
+		}
+	})
+
+	t.Run("partial overlap persists nothing", func(t *testing.T) {
+		t.Parallel()
+
+		store := setupDynamoStore(t)
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+		aggregateID := "atomic-aggregate"
+
+		if err := store.Append(ctx, aggregateID, -1,
+			createTestEvent(aggregateID, "event-1", "test.created", 1)); err != nil {
+			t.Fatalf("failed to append seed event: %v", err)
+		}
+
+		// Batch where one event collides (seq 1) and one is new (seq 2):
+		// the transaction must be all-or-nothing, so seq 2 must NOT land.
+		err := store.Append(ctx, aggregateID, -1,
+			createTestEvent(aggregateID, "colliding-event", "test.updated", 1),
+			createTestEvent(aggregateID, "new-event", "test.updated", 2),
+		)
+		if !errors.Is(err, domain.ErrConcurrencyConflict) {
+			t.Fatalf("error = %v, want errors.Is(err, ErrConcurrencyConflict)", err)
+		}
+
+		events, err := store.GetEvents(ctx, aggregateID)
+		if err != nil {
+			t.Fatalf("failed to get events: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("expected only the seed event after rejected batch, got %d events", len(events))
+		}
+		if events[0].ID != "event-1" {
+			t.Errorf("surviving event ID = %q, want event-1", events[0].ID)
 		}
 	})
 }

--- a/pkg/eventsourcing/infrastructure/file_store.go
+++ b/pkg/eventsourcing/infrastructure/file_store.go
@@ -193,22 +193,30 @@ func (f *FileStore) Append(ctx context.Context, aggregateID string, expectedVers
 
 // GetEvents retrieves all events for the given aggregate ID.
 func (f *FileStore) GetEvents(ctx context.Context, aggregateID string) ([]domain.EventEnvelope[any], error) {
+	// Fast path: cache hit under the read lock.
 	f.mu.RLock()
-	defer f.mu.RUnlock()
+	events, exists := f.cache[aggregateID]
+	f.mu.RUnlock()
+	if exists {
+		return events, nil
+	}
 
-	// Check cache first
+	// Cache miss: caching the loaded events is a map write, so it needs the
+	// write lock. Re-check after acquiring it — another goroutine may have
+	// populated the entry between the two locks.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	if events, exists := f.cache[aggregateID]; exists {
 		return events, nil
 	}
 
-	// Load from disk
 	filePath := f.getFilePath(aggregateID)
 	events, err := f.loadFromFile(filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load events for aggregate %s: %w", aggregateID, err)
 	}
 
-	// Cache the result
 	f.cache[aggregateID] = events
 
 	return events, nil

--- a/pkg/eventsourcing/infrastructure/file_store_test.go
+++ b/pkg/eventsourcing/infrastructure/file_store_test.go
@@ -3,8 +3,10 @@ package infrastructure_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
@@ -245,6 +247,173 @@ func TestFileStore_NewFileStore(t *testing.T) {
 		_, err := infrastructure.NewFileStore("")
 		if err == nil {
 			t.Fatal("expected error for empty directory, got nil")
+		}
+	})
+}
+
+// TestFileStore_ConcurrentAccess hammers a cold-cache store from many
+// goroutines. Reading an uncached aggregate populates the cache, so
+// concurrent reads exercise the read-path cache write that previously
+// happened under RLock and crashed with "concurrent map writes" (caught
+// only under -race with concurrent callers, which no test had).
+// GetEventsFromVersion, GetEventsRange, and GetCurrentVersion all funnel
+// through GetEvents, so they are exercised alongside it.
+func TestFileStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("concurrent reads on uncached aggregates", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := setupTestDir(t)
+		defer cleanupTestDir(t, baseDir)
+
+		// NewFileStore pre-loads every existing file into the cache, so the
+		// only reliable cache misses are aggregates with no file at all.
+		// Every goroutine's first read of each ID below races through the
+		// miss path, which loads from disk and writes the cache entry.
+		store, err := infrastructure.NewFileStore(baseDir)
+		if err != nil {
+			t.Fatalf("failed to create file store: %v", err)
+		}
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+
+		const goroutines = 16
+		const aggregates = 8
+
+		var wg sync.WaitGroup
+		errCh := make(chan error, goroutines*aggregates*4)
+
+		for range goroutines {
+			wg.Go(func() {
+				for a := range aggregates {
+					id := fmt.Sprintf("cold-aggregate-%d", a)
+					if _, err := store.GetEvents(ctx, id); err != nil {
+						errCh <- fmt.Errorf("GetEvents(%s): %w", id, err)
+					}
+					if _, err := store.GetEventsFromVersion(ctx, id, 1); err != nil {
+						errCh <- fmt.Errorf("GetEventsFromVersion(%s): %w", id, err)
+					}
+					if _, err := store.GetEventsRange(ctx, id, 1, 10); err != nil {
+						errCh <- fmt.Errorf("GetEventsRange(%s): %w", id, err)
+					}
+					if _, err := store.GetCurrentVersion(ctx, id); err != nil {
+						errCh <- fmt.Errorf("GetCurrentVersion(%s): %w", id, err)
+					}
+				}
+			})
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Error(err)
+		}
+	})
+
+	t.Run("concurrent appends and reads", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := setupTestDir(t)
+		defer cleanupTestDir(t, baseDir)
+
+		store, err := infrastructure.NewFileStore(baseDir)
+		if err != nil {
+			t.Fatalf("failed to create file store: %v", err)
+		}
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+		const writers = 8
+
+		var wg sync.WaitGroup
+		// Worst case per writer: 1 append error + `writers` read errors.
+		// Sends block (never drop) on a full buffer and nothing drains until
+		// after wg.Wait(), so an undersized buffer would deadlock the test
+		// in exactly the failure case it exists to report.
+		errCh := make(chan error, writers*(writers+1))
+
+		// Each writer appends to its own aggregate while concurrently
+		// reading every other writer's (mostly uncached) aggregate.
+		for w := range writers {
+			wg.Go(func() {
+				id := fmt.Sprintf("writer-aggregate-%d", w)
+				ev := createTestEvent(id, fmt.Sprintf("event-%d", w), "test.created", 1)
+				if err := store.Append(ctx, id, 0, ev); err != nil {
+					errCh <- fmt.Errorf("Append(%s): %w", id, err)
+				}
+				for other := range writers {
+					otherID := fmt.Sprintf("writer-aggregate-%d", other)
+					if _, err := store.GetEvents(ctx, otherID); err != nil {
+						errCh <- fmt.Errorf("GetEvents(%s): %w", otherID, err)
+					}
+				}
+			})
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Error(err)
+		}
+
+		// Every writer's event must have survived.
+		for w := range writers {
+			id := fmt.Sprintf("writer-aggregate-%d", w)
+			version, err := store.GetCurrentVersion(ctx, id)
+			if err != nil {
+				t.Errorf("GetCurrentVersion(%s): %v", id, err)
+				continue
+			}
+			if version != 1 {
+				t.Errorf("GetCurrentVersion(%s) = %d, want 1", id, version)
+			}
+		}
+	})
+
+	t.Run("optimistic append has exactly one winner", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := setupTestDir(t)
+		defer cleanupTestDir(t, baseDir)
+
+		store, err := infrastructure.NewFileStore(baseDir)
+		if err != nil {
+			t.Fatalf("failed to create file store: %v", err)
+		}
+		defer func() { _ = store.Close() }()
+
+		ctx := context.Background()
+		const contenders = 8
+		aggregateID := "contended-aggregate"
+
+		var wg sync.WaitGroup
+		results := make(chan error, contenders)
+
+		for c := range contenders {
+			wg.Go(func() {
+				ev := createTestEvent(aggregateID, fmt.Sprintf("contender-%d", c), "test.created", 1)
+				results <- store.Append(ctx, aggregateID, 0, ev)
+			})
+		}
+		wg.Wait()
+		close(results)
+
+		winners, conflicts := 0, 0
+		for err := range results {
+			switch {
+			case err == nil:
+				winners++
+			case errors.Is(err, domain.ErrConcurrencyConflict):
+				conflicts++
+			default:
+				t.Errorf("unexpected append error: %v", err)
+			}
+		}
+		if winners != 1 {
+			t.Errorf("winners = %d, want exactly 1", winners)
+		}
+		if conflicts != contenders-1 {
+			t.Errorf("conflicts = %d, want %d", conflicts, contenders-1)
 		}
 	})
 }


### PR DESCRIPTION
Closes the remaining stories of epic #45 (#46, #47, #48; #49 was already done on main by d3d869a and is closed with verification notes).

## Story #46 — `SubscriptionClaim.IsActiveAt` (3ff59b0)
- New `IsActiveAt(now time.Time)`; `IsActive()` delegates with `time.Now()`
- RevenueCat/Stripe adapter tests assert activity via `IsActiveAt(now)` against the same frozen instant injected into the adapter — no assertion depends on the wall clock anymore (the prior fix on main anchored fixtures on real `time.Now()`, which worked but stayed wall-clock-dependent)
- New `TestSubscriptionClaim_IsActiveAt` pins the boundary: `ExpiresAt` strictly before now deactivates, equality stays active

## Story #47 — FileStore concurrent map write (3648fd0)
- `GetEvents` populated the cache under `RLock`; two concurrent reads of an uncached aggregate crashed with `fatal error: concurrent map writes`. All read methods funnel through it. Now double-checked locking (RLock hit path, full Lock + re-check on miss)
- New `TestFileStore_ConcurrentAccess`: concurrent cold-cache reads across all four read methods, mixed appends+reads, and N-contender optimistic appends asserting exactly one winner / `errors.Is(ErrConcurrencyConflict)` losers
- Verified the test crashes the pre-fix code under `-race` and passes post-fix

## Story #48 — Dynamo `-1` append never overwrites (728686b)
- `appendWithoutVersionCheck` used `BatchWriteItem`, whose PutRequests silently REPLACE an existing `(aggregate_id, sequence_no)` item, and could persist earlier batches before erroring — silent data destruction with no rollback
- Now conditional `TransactWriteItems` (`attribute_not_exists` per Put), all-or-nothing, shared helpers with the version-checked path; duplicates surface as `errors.Is(err, ErrConcurrencyConflict)`
- Conflict errors name the exact cause (failed version check vs the colliding sequence number); transient `TransactionConflict` maps to the retry sentinel
- `PERICARP_REQUIRE_DOCKER_TESTS=1` in CI turns Dynamo-container startup failures into test failures instead of green skips
- New `TestDynamoStore_NoVersionCheck_NeverOverwrites` (duplicate rejected + original intact; partially-colliding batch persists nothing). Note: verified compile+skip locally (no Docker on the dev machine); these run in CI

## Verification
- `go vet ./...` clean, `go test -race -count=1 ./...` green across all 17 packages
- Each story was reviewed by the pr-review-toolkit agents (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter) and all actionable findings were resolved in the commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)