### PR TITLE
fix(subscriptions): cut redundant checkpoint writes; join ambient batch tx in Append

### DIFF
--- a/pkg/eventsourcing/infrastructure/gorm_store.go
+++ b/pkg/eventsourcing/infrastructure/gorm_store.go
@@ -126,6 +126,10 @@ func (s *GormEventStore) appendCheckingVersion(tx *gorm.DB, aggregateID string, 
 // savepoint so it does not poison the surrounding batch, which stays usable for
 // further appends and its eventual commit. On success the events commit
 // atomically with the batch.
+//
+// The savepoint is released on both paths (ROLLBACK TO keeps its savepoint
+// alive) so a long-running batch performing many appends keeps a bounded
+// savepoint stack instead of accumulating one entry per append.
 func (s *GormEventStore) appendInTx(tx *gorm.DB, aggregateID string, expectedVersion int, models []GormEventModel) error {
 	name := fmt.Sprintf("pericarp_append_sp_%d", s.savepointSeq.Add(1))
 	if err := tx.SavePoint(name).Error; err != nil {
@@ -142,9 +146,24 @@ func (s *GormEventStore) appendInTx(tx *gorm.DB, aggregateID string, expectedVer
 		if rbErr := tx.RollbackTo(name).Error; rbErr != nil {
 			return fmt.Errorf("%w (rollback to savepoint %s failed: %v)", err, name, rbErr)
 		}
+		if relErr := releaseSavepoint(tx, name); relErr != nil {
+			return fmt.Errorf("%w (release of savepoint %s failed: %v)", err, name, relErr)
+		}
 		return err
 	}
+	if err := releaseSavepoint(tx, name); err != nil {
+		return fmt.Errorf("failed to release append savepoint %s: %w", name, err)
+	}
 	return nil
+}
+
+// releaseSavepoint discards a savepoint without rolling back to it. GORM's
+// savepoint interface only exposes SavePoint and RollbackTo, so the release is
+// issued directly; RELEASE SAVEPOINT is supported by both engines this store
+// runs on (SQLite and Postgres). The name is internally generated
+// ("pericarp_append_sp_<n>"), never caller input.
+func releaseSavepoint(tx *gorm.DB, name string) error {
+	return tx.Exec("RELEASE SAVEPOINT " + name).Error
 }
 
 // ReadAfter returns committed events with Position > afterPosition across all

--- a/pkg/eventsourcing/infrastructure/gorm_store.go
+++ b/pkg/eventsourcing/infrastructure/gorm_store.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
 	"gorm.io/gorm"
 )
 
@@ -16,6 +18,9 @@ var _ domain.EventStore = (*GormEventStore)(nil)
 type GormEventStore struct {
 	repo *GormEventRepository
 	db   *gorm.DB
+	// savepointSeq names the savepoint each ambient-batch append brackets
+	// itself with; monotonic so nested appends within one batch never collide.
+	savepointSeq atomic.Uint64
 }
 
 // NewGormEventStore creates a new GORM-based event store and auto-migrates the
@@ -36,6 +41,10 @@ func NewGormEventStore(db *gorm.DB) (*GormEventStore, error) {
 
 // Append appends events to the store for the given aggregate.
 // If expectedVersion is not -1, optimistic concurrency control is enforced within a transaction.
+// When the caller's context carries a subscription batch transaction
+// (subscriptions.TxFromContext) — e.g. a handler appending events from inside
+// its own batch — the append joins that transaction, bracketed by a savepoint,
+// instead of opening its own, and commits atomically with the batch.
 func (s *GormEventStore) Append(ctx context.Context, aggregateID string, expectedVersion int, events ...domain.EventEnvelope[any]) error {
 	if len(events) == 0 {
 		return nil
@@ -59,31 +68,74 @@ func (s *GormEventStore) Append(ctx context.Context, aggregateID string, expecte
 		models[i] = m
 	}
 
+	// Join an ambient subscription batch transaction when present. Opening a
+	// second write transaction from the same goroutine while the batch already
+	// holds the database write lock (SQLite BEGIN IMMEDIATE) is an unresolvable
+	// self-wait that burns the whole busy_timeout before failing.
+	if tx := subscriptions.TxFromContext(ctx); tx != nil {
+		return s.appendInTx(tx, aggregateID, expectedVersion, models)
+	}
+
 	if expectedVersion == -1 {
 		return s.repo.SaveEvents(ctx, models)
 	}
 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var maxSeq *int
-		if err := tx.Model(&GormEventModel{}).
-			Where("aggregate_id = ?", aggregateID).
-			Select("MAX(sequence_no)").
-			Scan(&maxSeq).Error; err != nil {
-			return fmt.Errorf("failed to check current version: %w", err)
-		}
-
-		currentVersion := 0
-		if maxSeq != nil {
-			currentVersion = *maxSeq
-		}
-
-		if currentVersion != expectedVersion {
-			return fmt.Errorf("%w: expected version %d, got %d",
-				domain.ErrConcurrencyConflict, expectedVersion, currentVersion)
-		}
-
-		return s.repo.insertEventsTx(tx, models)
+		return s.appendCheckingVersion(tx, aggregateID, expectedVersion, models)
 	})
+}
+
+// appendCheckingVersion enforces optimistic concurrency (expectedVersion != -1)
+// and inserts the events, all within tx. Shared by the standalone-transaction
+// path and the ambient batch path so both check-then-insert identically.
+func (s *GormEventStore) appendCheckingVersion(tx *gorm.DB, aggregateID string, expectedVersion int, models []GormEventModel) error {
+	var maxSeq *int
+	if err := tx.Model(&GormEventModel{}).
+		Where("aggregate_id = ?", aggregateID).
+		Select("MAX(sequence_no)").
+		Scan(&maxSeq).Error; err != nil {
+		return fmt.Errorf("failed to check current version: %w", err)
+	}
+
+	currentVersion := 0
+	if maxSeq != nil {
+		currentVersion = *maxSeq
+	}
+
+	if currentVersion != expectedVersion {
+		return fmt.Errorf("%w: expected version %d, got %d",
+			domain.ErrConcurrencyConflict, expectedVersion, currentVersion)
+	}
+
+	return s.repo.insertEventsTx(tx, models)
+}
+
+// appendInTx runs an append inside an ambient transaction (a subscription batch
+// transaction joined via subscriptions.TxFromContext). The append is bracketed
+// by a uniquely named savepoint: a batch may contain multiple appends, and a
+// failed one — a version conflict or an insert error — rolls back only to its
+// savepoint so it does not poison the surrounding batch, which stays usable for
+// further appends and its eventual commit. On success the events commit
+// atomically with the batch.
+func (s *GormEventStore) appendInTx(tx *gorm.DB, aggregateID string, expectedVersion int, models []GormEventModel) error {
+	name := fmt.Sprintf("pericarp_append_sp_%d", s.savepointSeq.Add(1))
+	if err := tx.SavePoint(name).Error; err != nil {
+		return fmt.Errorf("failed to open append savepoint: %w", err)
+	}
+
+	var err error
+	if expectedVersion == -1 {
+		err = s.repo.insertEventsTx(tx, models)
+	} else {
+		err = s.appendCheckingVersion(tx, aggregateID, expectedVersion, models)
+	}
+	if err != nil {
+		if rbErr := tx.RollbackTo(name).Error; rbErr != nil {
+			return fmt.Errorf("%w (rollback to savepoint %s failed: %v)", err, name, rbErr)
+		}
+		return err
+	}
+	return nil
 }
 
 // ReadAfter returns committed events with Position > afterPosition across all

--- a/pkg/eventsourcing/infrastructure/gorm_store.go
+++ b/pkg/eventsourcing/infrastructure/gorm_store.go
@@ -68,12 +68,21 @@ func (s *GormEventStore) Append(ctx context.Context, aggregateID string, expecte
 		models[i] = m
 	}
 
-	// Join an ambient subscription batch transaction when present. Opening a
-	// second write transaction from the same goroutine while the batch already
-	// holds the database write lock (SQLite BEGIN IMMEDIATE) is an unresolvable
-	// self-wait that burns the whole busy_timeout before failing.
-	if tx := subscriptions.TxFromContext(ctx); tx != nil {
-		return s.appendInTx(tx, aggregateID, expectedVersion, models)
+	// Join an ambient subscription batch transaction when present — but only
+	// one that belongs to this store's own connection pool. A batch tx cloned
+	// off a different *gorm.DB carries a foreign connection; joining it would
+	// write events into whatever database that connection points at. Pool
+	// identity (kept on the cloned tx's Config; the live tx connection lives on
+	// Statement.ConnPool) distinguishes "batch on my database" from a foreign
+	// one, matching the guard in subscriptions/gorm_parking.go. tx.WithContext
+	// rebinds the append to ctx so statement deadlines and cancellation apply.
+	//
+	// Opening a second write transaction from the same goroutine while our own
+	// batch already holds the database write lock (SQLite BEGIN IMMEDIATE) is an
+	// unresolvable self-wait that burns the whole busy_timeout before failing;
+	// joining the batch avoids it.
+	if tx := subscriptions.TxFromContext(ctx); tx != nil && tx.ConnPool == s.db.ConnPool {
+		return s.appendInTx(tx.WithContext(ctx), aggregateID, expectedVersion, models)
 	}
 
 	if expectedVersion == -1 {

--- a/pkg/eventsourcing/subscriptions/gorm_ambient_append_test.go
+++ b/pkg/eventsourcing/subscriptions/gorm_ambient_append_test.go
@@ -1,0 +1,144 @@
+package subscriptions_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+)
+
+// newBatchLockedFixture opens a file-backed SQLite database whose transactions
+// BEGIN IMMEDIATE (_txlock=immediate), so a subscription batch grabs the
+// database write lock for its whole lifetime — the exact condition under which
+// a nested append that opened its own transaction would self-deadlock. The
+// busy_timeout is short so that, absent the ambient-tx join, the self-wait
+// fails fast instead of hanging the suite.
+func newBatchLockedFixture(t *testing.T) (domain.EventStore, *subscriptions.GormCheckpointStore) {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "ambient.db") +
+		"?_pragma=busy_timeout(500)&_pragma=journal_mode(WAL)&_txlock=immediate"
+	_, store, checkpoints := newGormFixtureDSN(t, dsn)
+	return store, checkpoints
+}
+
+// TestGormEventStore_AppendJoinsAmbientBatchTx is the core regression for
+// wepala/weos#426: an append issued from inside a subscription batch (the
+// batch already holding the SQLite write lock) must join the batch transaction
+// and return promptly, then commit atomically with the batch — not open a
+// second transaction and burn the busy_timeout in a self-wait.
+func TestGormEventStore_AppendJoinsAmbientBatchTx(t *testing.T) {
+	t.Parallel()
+
+	store, checkpoints := newBatchLockedFixture(t)
+	ctx := context.Background()
+
+	batch, acquired, err := checkpoints.Acquire(ctx, "appender")
+	if err != nil || !acquired {
+		t.Fatalf("failed to acquire batch (acquired=%v): %v", acquired, err)
+	}
+	hctx := batch.HandlerContext(ctx)
+
+	// Take the batch write lock the way a real handler would: write a
+	// projection row through the batch transaction before appending. The batch
+	// now holds SQLite's single writer slot, so a nested append that opened its
+	// own transaction would deadlock.
+	if tx := subscriptions.TxFromContext(hctx); tx != nil {
+		if err := tx.Create(&projectionRow{EventID: "lock-holder"}).Error; err != nil {
+			t.Fatalf("failed to take the batch write lock: %v", err)
+		}
+	} else {
+		t.Fatal("expected the batch transaction in the handler context")
+	}
+
+	// Append from inside the batch. Without the ambient-tx join this opens a
+	// second write transaction on another pool connection, self-waits on the
+	// write lock the batch already holds, and BUSY-fails after busy_timeout.
+	// With the fix it writes through the batch tx and returns promptly.
+	done := make(chan error, 1)
+	go func() {
+		done <- store.Append(hctx, "agg-inbatch", -1,
+			createTestEvent("agg-inbatch", "ev-inbatch", "test.created", 1))
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ambient append failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ambient append did not return promptly — BUSY self-wait?")
+	}
+
+	// The event lives in the uncommitted batch transaction: invisible to a
+	// fresh connection until the batch commits.
+	if _, err := store.GetEventByID(ctx, "ev-inbatch"); !errors.Is(err, domain.ErrEventNotFound) {
+		t.Fatalf("expected ev-inbatch invisible before commit, got %v", err)
+	}
+
+	if err := batch.Commit(ctx, 1); err != nil {
+		t.Fatalf("failed to commit batch: %v", err)
+	}
+
+	// Committed atomically with the batch — now visible.
+	got, err := store.GetEventByID(ctx, "ev-inbatch")
+	if err != nil {
+		t.Fatalf("expected ev-inbatch visible after commit: %v", err)
+	}
+	if got.ID != "ev-inbatch" {
+		t.Fatalf("expected ev-inbatch, got %s", got.ID)
+	}
+}
+
+// TestGormEventStore_AmbientAppendFailureRollsBackToSavepoint pins the
+// savepoint bracketing: a failing append inside a batch rolls back only to its
+// own savepoint, leaving earlier appends intact and the batch usable for
+// further appends and its commit.
+func TestGormEventStore_AmbientAppendFailureRollsBackToSavepoint(t *testing.T) {
+	t.Parallel()
+
+	store, checkpoints := newBatchLockedFixture(t)
+	ctx := context.Background()
+
+	batch, acquired, err := checkpoints.Acquire(ctx, "savepointer")
+	if err != nil || !acquired {
+		t.Fatalf("failed to acquire batch (acquired=%v): %v", acquired, err)
+	}
+	hctx := batch.HandlerContext(ctx)
+
+	// A good append inside the batch (also takes the write lock).
+	if err := store.Append(hctx, "agg-a", -1,
+		createTestEvent("agg-a", "ev-a", "test.created", 1)); err != nil {
+		t.Fatalf("first append failed: %v", err)
+	}
+
+	// A failing append (wrong expectedVersion) must roll back to its savepoint
+	// and surface the conflict, without poisoning the batch.
+	err = store.Append(hctx, "agg-b", 7,
+		createTestEvent("agg-b", "ev-b", "test.created", 1))
+	if !errors.Is(err, domain.ErrConcurrencyConflict) {
+		t.Fatalf("expected ErrConcurrencyConflict from the bad append, got %v", err)
+	}
+
+	// The batch is still usable: another good append then a commit succeed.
+	if err := store.Append(hctx, "agg-c", -1,
+		createTestEvent("agg-c", "ev-c", "test.created", 1)); err != nil {
+		t.Fatalf("post-failure append failed (batch poisoned?): %v", err)
+	}
+	if err := batch.Commit(ctx, 1); err != nil {
+		t.Fatalf("failed to commit batch: %v", err)
+	}
+
+	// ev-a and ev-c committed; ev-b rolled back to its savepoint.
+	if _, err := store.GetEventByID(ctx, "ev-a"); err != nil {
+		t.Fatalf("expected ev-a committed: %v", err)
+	}
+	if _, err := store.GetEventByID(ctx, "ev-c"); err != nil {
+		t.Fatalf("expected ev-c committed: %v", err)
+	}
+	if _, err := store.GetEventByID(ctx, "ev-b"); !errors.Is(err, domain.ErrEventNotFound) {
+		t.Fatalf("expected ev-b rolled back and absent, got %v", err)
+	}
+}

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
@@ -3,6 +3,7 @@ package subscriptions
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -34,6 +35,10 @@ func (GormCheckpointModel) TableName() string {
 type GormCheckpointStore struct {
 	db       *gorm.DB
 	postgres bool
+	// ensured memoizes subscribers whose checkpoint row has been confirmed to
+	// exist for this store's lifetime, so ensure() runs once per subscriber
+	// instead of on every Acquire (see ensureOnce).
+	ensured sync.Map
 }
 
 var _ CheckpointStore = (*GormCheckpointStore)(nil)
@@ -57,9 +62,10 @@ func NewGormCheckpointStore(db *gorm.DB) (*GormCheckpointStore, error) {
 // Acquire begins a batch transaction holding the subscriber's checkpoint row.
 // On Postgres, acquired is false when another process holds the row.
 func (g *GormCheckpointStore) Acquire(ctx context.Context, subscriber string) (Batch, bool, error) {
-	// Ensure the row exists before locking it. Runs outside the batch
+	// Ensure the row exists before locking it, at most once per subscriber for
+	// this store's lifetime (see ensureOnce). Runs outside the batch
 	// transaction so a no-op conflict never interacts with row locks.
-	if err := g.ensure(ctx, subscriber, 0); err != nil {
+	if err := g.ensureOnce(ctx, subscriber); err != nil {
 		return nil, false, err
 	}
 
@@ -120,6 +126,29 @@ func (g *GormCheckpointStore) Reset(ctx context.Context, subscriber string, posi
 		Columns:   []clause.Column{{Name: "subscriber"}},
 		DoUpdates: clause.Assignments(map[string]any{"position": position, "updated_at": time.Now()}),
 	}).Create(&GormCheckpointModel{Subscriber: subscriber, Position: position, UpdatedAt: time.Now()}).Error
+}
+
+// ensureOnce runs ensure() at most once per subscriber for this store's
+// lifetime, memoizing the result so the INSERT ... ON CONFLICT DO NOTHING no
+// longer runs on every Acquire — that redundant write transaction per
+// subscriber wake is gone after the first one.
+//
+// Behaviour change from healing every cycle: a checkpoint row DELETEd out from
+// under a running store is no longer recreated by the next Acquire. Acquire
+// then fails with "checkpoint row ... disappeared" on SQLite, or skips the
+// cycle on Postgres (an absent row is indistinguishable from one locked by
+// another replica). Reset() remains the supported way to move or recreate a
+// checkpoint, and a fresh store — e.g. after a process restart — re-ensures
+// the row on first Acquire.
+func (g *GormCheckpointStore) ensureOnce(ctx context.Context, subscriber string) error {
+	if _, ok := g.ensured.Load(subscriber); ok {
+		return nil
+	}
+	if err := g.ensure(ctx, subscriber, 0); err != nil {
+		return err
+	}
+	g.ensured.Store(subscriber, struct{}{})
+	return nil
 }
 
 // ensure creates the checkpoint row at the given position if it doesn't exist.

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
@@ -141,9 +141,18 @@ func (g *GormCheckpointStore) Reset(ctx context.Context, subscriber string, posi
 // Concurrency: a plain Load-then-ensure would let two goroutines racing the
 // first Acquire (e.g. a concurrent wake burst) both miss the memo and both run
 // ensure(), re-introducing the write amplification this removes. The
-// singleflight collapses them into one execution the others wait on. ensure()
-// runs inside that flight and the memo is set only on success, so a failed
-// ensure leaves nothing memoized and the next Acquire retries.
+// singleflight collapses them into one execution. The memo is set only on
+// success, so a failed ensure leaves nothing memoized and the next Acquire
+// retries.
+//
+// Cancellation: each caller waits on the flight via DoChan and its own
+// ctx.Done, so a caller whose ctx is cancelled returns promptly instead of
+// blocking behind another goroutine's in-flight ensure (which may be sitting
+// on a DB lock for the whole busy_timeout). The flight itself runs on a
+// WithoutCancel context: singleflight hands the first caller's ctx to the
+// shared work, and letting that caller's cancellation fail the INSERT would
+// poison the result for every joined waiter (the same pattern as the
+// registration singleflight in auth/infrastructure/providers/mastodon.go).
 //
 // Behaviour change from healing every cycle: a checkpoint row DELETEd out from
 // under a running store is no longer recreated by the next Acquire. Acquire
@@ -156,19 +165,25 @@ func (g *GormCheckpointStore) ensureOnce(ctx context.Context, subscriber string)
 	if _, ok := g.ensured.Load(subscriber); ok {
 		return nil
 	}
-	_, err, _ := g.ensuring.Do(subscriber, func() (any, error) {
+	sharedCtx := context.WithoutCancel(ctx)
+	ch := g.ensuring.DoChan(subscriber, func() (any, error) {
 		// Re-check inside the flight: a prior flight for this subscriber may
 		// have already ensured the row while this call was queued.
 		if _, ok := g.ensured.Load(subscriber); ok {
 			return nil, nil
 		}
-		if err := g.ensure(ctx, subscriber, 0); err != nil {
+		if err := g.ensure(sharedCtx, subscriber, 0); err != nil {
 			return nil, err
 		}
 		g.ensured.Store(subscriber, struct{}{})
 		return nil, nil
 	})
-	return err
+	select {
+	case res := <-ch:
+		return res.Err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // ensure creates the checkpoint row at the given position if it doesn't exist.

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -39,6 +40,10 @@ type GormCheckpointStore struct {
 	// exist for this store's lifetime, so ensure() runs once per subscriber
 	// instead of on every Acquire (see ensureOnce).
 	ensured sync.Map
+	// ensuring collapses concurrent first-time ensures for the same subscriber
+	// into a single flight, so a concurrent wake burst can't slip N goroutines
+	// past the ensured memo and fire N redundant INSERTs (see ensureOnce).
+	ensuring singleflight.Group
 }
 
 var _ CheckpointStore = (*GormCheckpointStore)(nil)
@@ -133,6 +138,13 @@ func (g *GormCheckpointStore) Reset(ctx context.Context, subscriber string, posi
 // longer runs on every Acquire — that redundant write transaction per
 // subscriber wake is gone after the first one.
 //
+// Concurrency: a plain Load-then-ensure would let two goroutines racing the
+// first Acquire (e.g. a concurrent wake burst) both miss the memo and both run
+// ensure(), re-introducing the write amplification this removes. The
+// singleflight collapses them into one execution the others wait on. ensure()
+// runs inside that flight and the memo is set only on success, so a failed
+// ensure leaves nothing memoized and the next Acquire retries.
+//
 // Behaviour change from healing every cycle: a checkpoint row DELETEd out from
 // under a running store is no longer recreated by the next Acquire. Acquire
 // then fails with "checkpoint row ... disappeared" on SQLite, or skips the
@@ -144,11 +156,19 @@ func (g *GormCheckpointStore) ensureOnce(ctx context.Context, subscriber string)
 	if _, ok := g.ensured.Load(subscriber); ok {
 		return nil
 	}
-	if err := g.ensure(ctx, subscriber, 0); err != nil {
-		return err
-	}
-	g.ensured.Store(subscriber, struct{}{})
-	return nil
+	_, err, _ := g.ensuring.Do(subscriber, func() (any, error) {
+		// Re-check inside the flight: a prior flight for this subscriber may
+		// have already ensured the row while this call was queued.
+		if _, ok := g.ensured.Load(subscriber); ok {
+			return nil, nil
+		}
+		if err := g.ensure(ctx, subscriber, 0); err != nil {
+			return nil, err
+		}
+		g.ensured.Store(subscriber, struct{}{})
+		return nil, nil
+	})
+	return err
 }
 
 // ensure creates the checkpoint row at the given position if it doesn't exist.

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +37,13 @@ func newGormFixture(t *testing.T) (*gorm.DB, domain.EventStore, *subscriptions.G
 	// never block writers — also what a production SQLite deployment of a
 	// background subscriber would run.
 	dsn := filepath.Join(t.TempDir(), "subscriptions.db") + "?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)"
+	return newGormFixtureDSN(t, dsn)
+}
+
+// newGormFixtureDSN is newGormFixture with an explicit DSN, so tests that need
+// specific SQLite locking behaviour (e.g. _txlock=immediate) can dictate it.
+func newGormFixtureDSN(t *testing.T, dsn string) (*gorm.DB, domain.EventStore, *subscriptions.GormCheckpointStore) {
+	t.Helper()
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
@@ -344,6 +352,41 @@ func TestGormCheckpointStore_AcquireCommitReset(t *testing.T) {
 	}
 	if position != 7 {
 		t.Fatalf("expected checkpoint 7, got %d", position)
+	}
+}
+
+// TestGormCheckpointStore_EnsuresRowOncePerSubscriber pins the memoization: the
+// checkpoint row is INSERTed once for a subscriber, not on every Acquire. A
+// gorm create-callback counts INSERT statements against subscriber_checkpoints
+// across two Acquire/Commit cycles and expects exactly one.
+func TestGormCheckpointStore_EnsuresRowOncePerSubscriber(t *testing.T) {
+	t.Parallel()
+
+	db, _, checkpoints := newGormFixture(t)
+	ctx := context.Background()
+
+	var inserts int64
+	if err := db.Callback().Create().After("gorm:create").
+		Register("test:count_checkpoint_inserts", func(tx *gorm.DB) {
+			if tx.Statement.Table == "subscriber_checkpoints" {
+				atomic.AddInt64(&inserts, 1)
+			}
+		}); err != nil {
+		t.Fatalf("failed to register callback: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		batch, acquired, err := checkpoints.Acquire(ctx, "memoized")
+		if err != nil || !acquired {
+			t.Fatalf("cycle %d: failed to acquire (acquired=%v): %v", i, acquired, err)
+		}
+		if err := batch.Commit(ctx, int64(i+1)); err != nil {
+			t.Fatalf("cycle %d: failed to commit: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt64(&inserts); got != 1 {
+		t.Fatalf("expected the checkpoint row ensured once across cycles, got %d INSERTs", got)
 	}
 }
 

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
@@ -439,6 +439,61 @@ func TestGormCheckpointStore_EnsuresRowOnceUnderConcurrentAcquire(t *testing.T) 
 	}
 }
 
+// TestGormCheckpointStore_EnsureRespectsCallerCancellation pins the
+// cancellation contract of the first-time ensure: a caller whose ctx expires
+// while the ensure INSERT is stuck behind the database write lock returns
+// promptly with the ctx error instead of blocking out the full busy_timeout —
+// and the ensure itself, deliberately detached from any one caller's ctx,
+// still completes once the lock frees, so the store converges.
+func TestGormCheckpointStore_EnsureRespectsCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	db, _, checkpoints := newGormFixture(t)
+
+	// Hold SQLite's database write lock in a separate transaction so the
+	// flight's ensure INSERT blocks against busy_timeout (10s in the fixture).
+	blocker := db.Begin()
+	if blocker.Error != nil {
+		t.Fatalf("failed to begin blocking tx: %v", blocker.Error)
+	}
+	if err := blocker.Create(&projectionRow{EventID: "lock-holder"}).Error; err != nil {
+		t.Fatalf("failed to take the write lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := checkpoints.Acquire(ctx, "cancellable")
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+	// Well under the 10s busy_timeout the blocked INSERT would otherwise burn.
+	if elapsed > 5*time.Second {
+		t.Fatalf("Acquire blocked %v despite ctx deadline; want prompt return", elapsed)
+	}
+
+	// Release the lock: the detached flight finishes its INSERT and memoizes,
+	// so a later Acquire with a healthy ctx succeeds.
+	if err := blocker.Rollback().Error; err != nil {
+		t.Fatalf("failed to release the write lock: %v", err)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		batch, acquired, err := checkpoints.Acquire(context.Background(), "cancellable")
+		if err == nil && acquired {
+			if err := batch.Rollback(); err != nil {
+				t.Fatalf("failed to rollback: %v", err)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("store never converged after lock release (acquired=%v): %v", acquired, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // TestSubscriber_ResetReplayRebuildsProjection covers the reset-to-replay flow
 // end to end on the database-backed stores: wipe the projection, reset the
 // checkpoint to 0, and the subscriber rebuilds the projection from history.

--- a/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
+++ b/pkg/eventsourcing/subscriptions/gorm_checkpoint_test.go
@@ -390,6 +390,55 @@ func TestGormCheckpointStore_EnsuresRowOncePerSubscriber(t *testing.T) {
 	}
 }
 
+// TestGormCheckpointStore_EnsuresRowOnceUnderConcurrentAcquire pins the
+// concurrency side of the memoization: a wake burst that races several first
+// Acquires for the same fresh subscriber must still ensure the checkpoint row
+// exactly once. A plain load-then-ensure would let every racer miss the memo
+// and fire its own INSERT — the write amplification the memo exists to remove.
+func TestGormCheckpointStore_EnsuresRowOnceUnderConcurrentAcquire(t *testing.T) {
+	t.Parallel()
+
+	db, _, checkpoints := newGormFixture(t)
+
+	var inserts int64
+	if err := db.Callback().Create().After("gorm:create").
+		Register("test:count_concurrent_checkpoint_inserts", func(tx *gorm.DB) {
+			if tx.Statement.Table == "subscriber_checkpoints" {
+				atomic.AddInt64(&inserts, 1)
+			}
+		}); err != nil {
+		t.Fatalf("failed to register callback: %v", err)
+	}
+
+	const racers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for range racers {
+		go func() {
+			defer wg.Done()
+			<-start // release all goroutines into Acquire together
+			batch, acquired, err := checkpoints.Acquire(context.Background(), "raced")
+			if err != nil {
+				t.Errorf("failed to acquire: %v", err)
+				return
+			}
+			if acquired {
+				// Release the batch transaction; the row stays ensured.
+				if err := batch.Rollback(); err != nil {
+					t.Errorf("failed to rollback: %v", err)
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&inserts); got != 1 {
+		t.Fatalf("expected the checkpoint row ensured once under concurrent Acquire, got %d INSERTs", got)
+	}
+}
+
 // TestSubscriber_ResetReplayRebuildsProjection covers the reset-to-replay flow
 // end to end on the database-backed stores: wipe the projection, reset the
 // checkpoint to 0, and the subscriber rebuilds the projection from history.


### PR DESCRIPTION
Companion change for [wepala/weos#426](https://github.com/wepala/weos/issues/426), which diagnosed `SQLITE_BUSY` under concurrent write bursts. The weos-side fix serializes SQLite write transactions with an in-process write gate; these two pericarp-side changes remove the write amplification and the self-wait that fed the contention.

## Change 1 — memoize checkpoint `ensure()`

`GormCheckpointStore.Acquire` called `ensure()` — an `INSERT ... ON CONFLICT DO NOTHING` guaranteeing the subscriber's checkpoint row exists — on **every** cycle, i.e. one wasted write transaction per subscriber wake, forever. A per-subscriber `sync.Map` memo (`ensureOnce`) now runs it once per store lifetime.

**Behaviour change:** a checkpoint row `DELETE`d out from under a running store is no longer healed by the next `Acquire`. It errors `checkpoint row ... disappeared` on SQLite, or skips the cycle on Postgres (an absent row is indistinguishable from one locked by another replica). `Reset()` remains the supported way to move or recreate a checkpoint, and a fresh store (process restart) re-ensures the row on first `Acquire`.

## Change 2 — `Append` joins an ambient batch transaction

A subscription handler that appends events from inside its own batch (e.g. weos memory consolidation creating fact resources) triggered a **new** DB transaction from the same goroutine while the batch transaction — held by `GormCheckpointStore.Acquire`, `BEGIN IMMEDIATE` on SQLite — already held the file's write lock. That is an unresolvable self-wait that burns the whole `busy_timeout` and then errors.

`GormEventStore.Append` now checks `subscriptions.TxFromContext(ctx)`; when non-nil it runs the entire append **inside** that transaction, bracketed by a per-call `SAVEPOINT` (unique name via an atomic counter on the store — a batch can contain multiple appends) with `ROLLBACK TO` on failure, so a failed append doesn't poison the batch. The version-check-then-insert body is factored into a helper shared by the ambient path and the existing `s.db.Transaction` path; the `expectedVersion == -1` ambient path inserts through the tx exactly as `SaveEvents`/`insertEventsTx` does, keeping global `Position` assignment identical.

Import direction `infrastructure` → `subscriptions` is cycle-free (`subscriptions` imports only `domain` + gorm + stdlib/pgx); verified before committing.

## Tests

- **Memoization:** a gorm create-callback counts `subscriber_checkpoints` `INSERT`s across two `Acquire`/`Commit` cycles for one subscriber and asserts exactly one.
- **Ambient append:** file-backed SQLite (`t.TempDir()`) with `_txlock=immediate` + `busy_timeout(500)` — both ambient tests fail with `SQLITE_BUSY` without the fix. Covers prompt success while the batch holds the write lock, invisibility before / atomic visibility after batch `Commit`, and a failing append (wrong `expectedVersion`) rolling back to its savepoint while the batch stays usable for a subsequent good append + commit.
- **Regression:** the full existing `./pkg/eventsourcing/...` suite passes unchanged with `-race`.

Suggested next tag: **v1.0.0-beta.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
