### PR TITLE
fix(auth): refuse sessions whose account membership was revoked

### DIFF
--- a/examples/authn/memrepo.go
+++ b/examples/authn/memrepo.go
@@ -248,6 +248,21 @@ func (m *MemoryAccountRepository) SaveMember(_ context.Context, accountID, agent
 	return nil
 }
 
+func (m *MemoryAccountRepository) RemoveMember(_ context.Context, accountID, agentID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.memberRoles, accountID+":"+agentID)
+	linked := m.memberAccounts[agentID]
+	kept := linked[:0]
+	for _, account := range linked {
+		if account.GetID() != accountID {
+			kept = append(kept, account)
+		}
+	}
+	m.memberAccounts[agentID] = kept
+	return nil
+}
+
 func (m *MemoryAccountRepository) FindAll(_ context.Context, _ string, _ int) (*repositories.PaginatedResponse[*entities.Account], error) {
 	return nil, nil
 }

--- a/pkg/auth/acceptance_test.go
+++ b/pkg/auth/acceptance_test.go
@@ -165,6 +165,7 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^"([^"]*)" signs in for the first time with a new credential$`, w.signsInFirstTime)
 	sc.Step(`^"([^"]*)" calls the protected endpoint$`, w.callsProtectedEndpoint)
 	sc.Step(`^"([^"]*)" switches the active account to "([^"]*)"$`, w.switchesActiveAccount)
+	sc.Step(`^"([^"]*)" is removed from the account "([^"]*)"$`, w.isRemovedFromAccount)
 	sc.Step(`^a session is requested for "([^"]*)" scoped to account "([^"]*)"$`, w.sessionRequestedScopedTo)
 	sc.Step(`^the session is scoped to account "([^"]*)"$`, w.sessionIsScopedTo)
 	sc.Step(`^the session is validated$`, w.sessionIsValidated)
@@ -684,6 +685,20 @@ func (w *world) callsProtectedEndpoint(_ string) error {
 	body := map[string]string{}
 	if decodeErr := json.NewDecoder(resp.Body).Decode(&body); decodeErr == nil {
 		w.lastBody = body
+	}
+	return nil
+}
+
+func (w *world) isRemovedFromAccount(agentID, accountID string) error {
+	role, err := w.accounts.FindMemberRole(context.Background(), accountID, agentID)
+	if err != nil {
+		return fmt.Errorf("read membership of %q in %q: %w", agentID, accountID, err)
+	}
+	if role == "" {
+		return fmt.Errorf("%q held no membership in %q to revoke", agentID, accountID)
+	}
+	if err := w.accounts.RemoveMember(context.Background(), accountID, agentID); err != nil {
+		return fmt.Errorf("revoke membership of %q in %q: %w", agentID, accountID, err)
 	}
 	return nil
 }

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ var (
 	ErrPasswordSupportNotConfigured = errors.New("authentication: password support not configured")
 	ErrPasswordCredentialMissing    = errors.New("authentication: password credential not found for agent")
 	ErrAccountNotMember             = errors.New("authentication: agent is not a member of the account")
+	ErrSessionAccountRevoked        = errors.New("authentication: session is scoped to an account the agent no longer belongs to")
 	// ErrJWTServiceNotConfigured is returned by RefreshIdentityToken when
 	// no JWTService is wired. Distinct from IssueIdentityToken's
 	// ("", nil) shape because refresh's sole purpose is to mint a token —
@@ -507,6 +509,16 @@ func (s *DefaultAuthenticationService) ScopeSessionToAccount(ctx context.Context
 	return nil
 }
 
+// accountsContain reports whether accountID is among accounts.
+func accountsContain(accounts []*entities.Account, accountID string) bool {
+	for _, account := range accounts {
+		if account != nil && account.GetID() == accountID {
+			return true
+		}
+	}
+	return false
+}
+
 // assertMember returns ErrAccountNotMember unless agentID holds a membership
 // in accountID.
 //
@@ -580,6 +592,52 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 		return nil, ErrSessionExpired
 	}
 
+	// Read the agent's live memberships. They serve two purposes: they let a
+	// session-derived identity match a JWT-derived one, and they are the only
+	// way to notice that the session's own account has been taken away.
+	//
+	// membershipsKnown stays false when there is no account repository or the
+	// lookup failed. The list is then not evidence of anything and must not be
+	// used to refuse: with no repository it is always empty, and callers turn
+	// a validation error into 401, so a database blip would log everyone out.
+	var memberships []string
+	membershipsKnown := false
+	if s.accounts != nil {
+		accounts, listErr := s.accounts.FindByMember(ctx, session.AgentID())
+		if listErr != nil {
+			s.logger.Warn(ctx, "auth: failed to list accounts for session identity",
+				"agent_id", session.AgentID(), "error", listErr)
+		} else {
+			membershipsKnown = true
+			seen := map[string]bool{}
+			for _, account := range accounts {
+				if account == nil || account.GetID() == "" || seen[account.GetID()] {
+					continue
+				}
+				seen[account.GetID()] = true
+				memberships = append(memberships, account.GetID())
+			}
+		}
+	}
+
+	// The session's account is recorded at sign-in and never revisited, so a
+	// membership revoked since then would otherwise keep authorizing writes
+	// into an account the agent has been removed from until the session
+	// expires. Refuse instead, and let the caller sign in again — unlike an
+	// unscoped session, signing in again does help here, which is why this
+	// gets its own error rather than reusing the unscoped one.
+	//
+	// Checked before the session is touched, so a refused request neither
+	// writes nor costs a permissions lookup. Refusals do not converge on
+	// their own — a polling client re-fires this on every request — so a
+	// refused session must not keep looking freshly used to anyone auditing
+	// last-accessed times.
+	if membershipsKnown && session.AccountID() != "" && !slices.Contains(memberships, session.AccountID()) {
+		s.logger.Warn(ctx, "auth: session scoped to a revoked membership",
+			"agent_id", session.AgentID(), "session_id", session.GetID(), "account_id", session.AccountID())
+		return nil, ErrSessionAccountRevoked
+	}
+
 	// Touch the session to update last accessed time
 	if touchErr := session.Touch(); touchErr != nil {
 		return nil, fmt.Errorf("failed to touch session: %w", touchErr)
@@ -597,32 +655,15 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 		}
 	}
 
-	// List every membership so a session-derived identity matches a
-	// JWT-derived one. An account switcher reading the identity then behaves
-	// the same under either middleware.
-	//
-	// The list is a convenience for switchers, never an authorization input —
-	// authorization uses AccountID. So a lookup failure degrades to the
-	// session's own account rather than failing the request: callers map a
-	// validation error to 401, and a database blip must not log everyone out.
+	// Session's own account first, then the rest, so the ordering a caller
+	// sees does not depend on repository order.
 	accountIDs := []string{}
 	if session.AccountID() != "" {
 		accountIDs = append(accountIDs, session.AccountID())
 	}
-	if s.accounts != nil {
-		accounts, listErr := s.accounts.FindByMember(ctx, session.AgentID())
-		if listErr != nil {
-			s.logger.Warn(ctx, "auth: failed to list accounts for session identity",
-				"agent_id", session.AgentID(), "error", listErr)
-		} else {
-			seen := map[string]bool{session.AccountID(): true}
-			for _, account := range accounts {
-				if account == nil || account.GetID() == "" || seen[account.GetID()] {
-					continue
-				}
-				seen[account.GetID()] = true
-				accountIDs = append(accountIDs, account.GetID())
-			}
+	for _, id := range memberships {
+		if id != session.AccountID() {
+			accountIDs = append(accountIDs, id)
 		}
 	}
 
@@ -712,6 +753,18 @@ func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, a
 		accounts, err = s.accounts.FindByMember(ctx, agent.GetID())
 		if err != nil {
 			return "", fmt.Errorf("authentication: failed to fetch accounts for token: %w", err)
+		}
+
+		// The active account is supplied by the caller, so it has to be
+		// checked against the memberships just fetched. Without this a token
+		// can be minted — including by RefreshIdentityToken, with no re-auth
+		// — for an account the agent has been removed from, which is the
+		// session defect reappearing on the JWT routes.
+		//
+		// Only enforced when an account repository exists. Without one the
+		// list is always empty and this would refuse every token.
+		if activeAccountID != "" && !accountsContain(accounts, activeAccountID) {
+			return "", fmt.Errorf("%w: agent %s in account %s", ErrAccountNotMember, agent.GetID(), activeAccountID)
 		}
 	}
 	var subscription *auth.SubscriptionClaim

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -287,6 +287,14 @@ func (m *mockAccountRepo) SaveMember(_ context.Context, accountID, agentID strin
 	return nil
 }
 
+func (m *mockAccountRepo) RemoveMember(_ context.Context, accountID, agentID string) error {
+	delete(m.memberRoles, accountID+":"+agentID)
+	if account, ok := m.byMember[agentID]; ok && account.GetID() == accountID {
+		delete(m.byMember, agentID)
+	}
+	return nil
+}
+
 func (m *mockAccountRepo) FindByID(_ context.Context, id string) (*entities.Account, error) {
 	account, ok := m.accounts[id]
 	if !ok {
@@ -983,7 +991,7 @@ func TestIssueIdentityToken_Success(t *testing.T) {
 		agents:      newMockAgentRepo(),
 		credentials: newMockCredentialRepo(),
 		sessions:    newMockSessionRepo(),
-		accounts:    newMockAccountRepo(),
+		accounts:    newTokenAccountRepo(t),
 		tokens:      newMockTokenStore(),
 		authz:       &mockAuthorizationChecker{},
 	}
@@ -1038,7 +1046,7 @@ func TestIssueIdentityToken_NilAgent_ReturnsError(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 
@@ -1079,7 +1087,7 @@ func TestIssueIdentityToken_NoClaimsEnricher_NilExtras(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
@@ -1102,7 +1110,7 @@ func TestIssueIdentityToken_ClaimsEnricher_PassesExtras(t *testing.T) {
 	}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(enricher),
 	)
@@ -1133,7 +1141,7 @@ func TestIssueIdentityToken_ClaimsEnricher_ErrorFailsIssuance(t *testing.T) {
 	}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(enricher),
 	)
@@ -1158,7 +1166,7 @@ func TestIssueIdentityToken_ClaimsEnricher_NilResult_NoExtras(t *testing.T) {
 	}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(enricher),
 	)
@@ -1185,7 +1193,7 @@ func TestIssueIdentityToken_ClaimsEnricher_EmptyResult_NoExtras(t *testing.T) {
 	}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(enricher),
 	)
@@ -1214,7 +1222,7 @@ func TestIssueIdentityToken_ClaimsEnricher_NilOption_Ignored(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(nil),
 	)
@@ -1241,7 +1249,7 @@ func TestIssueIdentityToken_SubscriptionAndEnricher_Coexist(t *testing.T) {
 	}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithSubscriptionService(subSvc),
 		application.WithClaimsEnricher(enricher),
@@ -1274,9 +1282,15 @@ func TestIssueIdentityToken_ClaimsEnricher_ReservedKeyRejected(t *testing.T) {
 	enricher := func(_ context.Context, _ *entities.Agent, _ []*entities.Account, _ string) (map[string]any, error) {
 		return map[string]any{"sub": "agent-spoof", "role": "admin"}, nil
 	}
+	// agent-1 must actually belong to account-1, or token issuance refuses
+	// the active account before the enricher — and its gate — ever runs.
+	accounts := newTokenAccountRepo(t)
+	accounts.accounts["account-1"] = newScopedAccount(t, "account-1", "Alice", entities.AccountTypePersonal, true)
+	accounts.memberRoles["account-1:agent-1"] = entities.RoleOwner
+
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), accounts,
 		application.WithJWTService(jwtSvc),
 		application.WithClaimsEnricher(enricher),
 	)
@@ -1321,7 +1335,7 @@ func TestIssueIdentityToken_ClaimsEnricher_EndToEnd(t *testing.T) {
 		agents:      newMockAgentRepo(),
 		credentials: newMockCredentialRepo(),
 		sessions:    newMockSessionRepo(),
-		accounts:    newMockAccountRepo(),
+		accounts:    newTokenAccountRepo(t),
 		tokens:      newMockTokenStore(),
 	}
 	svc := application.NewDefaultAuthenticationService(
@@ -1392,7 +1406,7 @@ func TestRefreshIdentityToken_EmptyAgentID_ReturnsError(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 
@@ -1411,7 +1425,7 @@ func TestRefreshIdentityToken_AgentNotFound_ReturnsError(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 
@@ -1433,7 +1447,7 @@ func TestRefreshIdentityToken_AgentLookupFails_ReturnsError(t *testing.T) {
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
 		&errorAgentRepo{err: wantErr},
-		newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 
@@ -1479,7 +1493,7 @@ func TestRefreshIdentityToken_RereadsEnricherAndSubscription(t *testing.T) {
 		agents:      newMockAgentRepo(),
 		credentials: newMockCredentialRepo(),
 		sessions:    newMockSessionRepo(),
-		accounts:    newMockAccountRepo(),
+		accounts:    newTokenAccountRepo(t),
 		tokens:      newMockTokenStore(),
 	}
 	svc := application.NewDefaultAuthenticationService(
@@ -1568,7 +1582,7 @@ func TestRefreshIdentityToken_SubscriptionLookupFails_FailOpen(t *testing.T) {
 		agents:      newMockAgentRepo(),
 		credentials: newMockCredentialRepo(),
 		sessions:    newMockSessionRepo(),
-		accounts:    newMockAccountRepo(),
+		accounts:    newTokenAccountRepo(t),
 	}
 	svc := application.NewDefaultAuthenticationService(
 		deps.providers, deps.agents, deps.credentials, deps.sessions, deps.accounts,
@@ -1607,7 +1621,7 @@ func TestRefreshIdentityToken_EnricherErrorFailsIssuance(t *testing.T) {
 		agents:      newMockAgentRepo(),
 		credentials: newMockCredentialRepo(),
 		sessions:    newMockSessionRepo(),
-		accounts:    newMockAccountRepo(),
+		accounts:    newTokenAccountRepo(t),
 	}
 	svc := application.NewDefaultAuthenticationService(
 		deps.providers, deps.agents, deps.credentials, deps.sessions, deps.accounts,
@@ -1652,7 +1666,7 @@ func TestIssueIdentityToken_NoSubscriptionService_OmitsClaim(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 	)
 
@@ -1680,7 +1694,7 @@ func TestIssueIdentityToken_WithSubscriptionService_EmbedsClaim(t *testing.T) {
 
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithSubscriptionService(subSvc),
 	)
@@ -1717,7 +1731,7 @@ func TestIssueIdentityToken_NonNilInactiveClaim_EmbeddedAsIs(t *testing.T) {
 
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithSubscriptionService(subSvc),
 	)
@@ -1744,7 +1758,7 @@ func TestIssueIdentityToken_SubscriptionLookupError_TokenStillIssued(t *testing.
 
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithSubscriptionService(subSvc),
 	)
@@ -1770,7 +1784,7 @@ func TestWithSubscriptionService_NilNoOp(t *testing.T) {
 	jwtSvc := &mockJWTService{}
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": &mockOAuthProvider{name: "google"}},
-		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newTokenAccountRepo(t),
 		application.WithJWTService(jwtSvc),
 		application.WithSubscriptionService(nil),
 	)
@@ -1817,6 +1831,7 @@ func (m *errorAccountRepo) FindMemberRole(_ context.Context, _, _ string) (strin
 	return "", nil
 }
 func (m *errorAccountRepo) SaveMember(_ context.Context, _, _, _ string) error { return nil }
+func (m *errorAccountRepo) RemoveMember(_ context.Context, _, _ string) error  { return nil }
 func (m *errorAccountRepo) FindAll(_ context.Context, _ string, _ int) (*repositories.PaginatedResponse[*entities.Account], error) {
 	return nil, nil
 }
@@ -1830,12 +1845,18 @@ func TestNewDefaultAuthenticationService_NilAuthorization(t *testing.T) {
 	session.ClearUncommittedEvents()
 	sessions.sessions["sess-1"] = session
 
+	// The session names acct-1, so the agent must hold that membership or
+	// validation refuses it as revoked.
+	accounts := newMockAccountRepo()
+	accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+
 	svc := application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{},
 		newMockAgentRepo(),
 		newMockCredentialRepo(),
 		sessions,
-		newMockAccountRepo(),
+		accounts,
 		application.WithTokenStore(newMockTokenStore()),
 		// no authorization checker — should default to nil
 	)
@@ -2242,4 +2263,231 @@ func TestDefaultAuthenticationService_ValidateSession_MembershipOutageDegrades(t
 	if len(info.AccountIDs) != 1 || info.AccountIDs[0] != "acct-1" {
 		t.Errorf("AccountIDs = %v, want it to fall back to [acct-1]", info.AccountIDs)
 	}
+}
+
+// --- Revoked membership (#70) ---
+
+// The session's account is recorded at sign-in and never revisited, so without
+// this check a removed member keeps writing into the account they were removed
+// from until the session expires.
+func TestDefaultAuthenticationService_ValidateSession_RefusesRevokedMembership(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	// Validation succeeds while the membership stands.
+	if _, err := svc.ValidateSession(ctx, session.GetID()); err != nil {
+		t.Fatalf("ValidateSession() before revocation: %v", err)
+	}
+
+	delete(deps.accounts.memberRoles, "acct-1:agent-1")
+
+	if _, err := svc.ValidateSession(ctx, session.GetID()); !errors.Is(err, application.ErrSessionAccountRevoked) {
+		t.Fatalf("ValidateSession() error = %v, want ErrSessionAccountRevoked", err)
+	}
+}
+
+// Detection is a read-path check and stays a pure read: nothing revokes the
+// session, so the row is untouched and the agent simply signs in again.
+func TestDefaultAuthenticationService_ValidateSession_RevokedMembershipLeavesSessionActive(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+	delete(deps.accounts.memberRoles, "acct-1:agent-1")
+
+	before := session.LastAccessedAt()
+
+	_, _ = svc.ValidateSession(ctx, session.GetID())
+
+	stored, err := deps.sessions.FindByID(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("FindByID() error: %v", err)
+	}
+	if !stored.Active() {
+		t.Error("session was revoked; detection must not change session state")
+	}
+	if stored.AccountID() != "acct-1" {
+		t.Errorf("AccountID() = %q, want it unchanged at %q", stored.AccountID(), "acct-1")
+	}
+	// A refusal never converges — a polling client re-fires it on every
+	// request — so a refused session must not keep looking freshly used to
+	// anyone auditing last-accessed times.
+	if !stored.LastAccessedAt().Equal(before) {
+		t.Errorf("LastAccessedAt moved from %v to %v; a refused request must not touch the session",
+			before, stored.LastAccessedAt())
+	}
+}
+
+// "Refuse but do not revoke" exists so the session survives a membership that
+// comes back — a non-transactional membership rewrite, replica lag, or an
+// async projection can make a valid membership momentarily invisible. Pinned
+// so a future "just revoke it" refactor cannot land silently.
+func TestDefaultAuthenticationService_ValidateSession_RecoversWhenMembershipReturns(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	delete(deps.accounts.memberRoles, "acct-1:agent-1")
+	if _, err := svc.ValidateSession(ctx, session.GetID()); !errors.Is(err, application.ErrSessionAccountRevoked) {
+		t.Fatalf("ValidateSession() during the gap = %v, want ErrSessionAccountRevoked", err)
+	}
+
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	info, err := svc.ValidateSession(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("ValidateSession() after the membership returned = %v, want it to validate again", err)
+	}
+	if info.AccountID != "acct-1" {
+		t.Errorf("AccountID = %q, want %q", info.AccountID, "acct-1")
+	}
+}
+
+// An unreadable membership list is not evidence of revocation. Callers turn a
+// validation error into 401, so refusing on a database blip would log every
+// user out at once.
+func TestDefaultAuthenticationService_ValidateSession_MembershipOutageDoesNotRefuse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	deps.accounts.findByMemberErr = errors.New("database unavailable")
+
+	info, err := svc.ValidateSession(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("ValidateSession() error = %v, want the session to still validate", err)
+	}
+	if info.AccountID != "acct-1" {
+		t.Errorf("AccountID = %q, want %q", info.AccountID, "acct-1")
+	}
+}
+
+// With no account repository there are no memberships to contradict, and the
+// list is empty for every session. Refusing on that would deny every request.
+func TestDefaultAuthenticationService_ValidateSession_NoAccountRepoDoesNotRefuse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	sessions := newMockSessionRepo()
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		newMockAgentRepo(),
+		newMockCredentialRepo(),
+		sessions,
+		nil,
+	)
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	info, err := svc.ValidateSession(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("ValidateSession() error = %v, want the session to validate", err)
+	}
+	if info.AccountID != "acct-1" {
+		t.Errorf("AccountID = %q, want %q", info.AccountID, "acct-1")
+	}
+}
+
+// The active account is supplied by the caller, so without this a removed
+// agent could mint a fresh token — via RefreshIdentityToken, with no re-auth
+// — still scoped to the account they were removed from. That is the session
+// defect reappearing on the JWT routes, which admit what the session routes
+// now refuse.
+func TestIssueIdentityToken_RefusesAccountTheAgentLeft(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	jwtSvc := &mockJWTService{}
+	accounts := newTokenAccountRepo(t)
+	accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), accounts,
+		application.WithJWTService(jwtSvc),
+	)
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() while a member: %v", err)
+	}
+
+	if err := accounts.RemoveMember(ctx, "acct-1", "agent-1"); err != nil {
+		t.Fatalf("RemoveMember() error: %v", err)
+	}
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1"); !errors.Is(err, application.ErrAccountNotMember) {
+		t.Fatalf("IssueIdentityToken() after removal = %v, want ErrAccountNotMember", err)
+	}
+}
+
+// Without an account repository there are no memberships to check against, so
+// enforcing would refuse every token.
+func TestIssueIdentityToken_NoAccountRepoStillIssues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	jwtSvc := &mockJWTService{}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), nil,
+		application.WithJWTService(jwtSvc),
+	)
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1"); err != nil {
+		t.Fatalf("IssueIdentityToken() with no account repository: %v", err)
+	}
+}
+
+// newTokenAccountRepo seeds the agent-1 / account-1 pair the identity-token
+// tests use. Token issuance now verifies the caller-supplied active account
+// against real memberships, so a fixture without one is refused before the
+// behaviour under test runs.
+func newTokenAccountRepo(t *testing.T) *mockAccountRepo {
+	t.Helper()
+	repo := newMockAccountRepo()
+	repo.accounts["account-1"] = newScopedAccount(t, "account-1", "Alice", entities.AccountTypePersonal, true)
+	repo.memberRoles["account-1:agent-1"] = entities.RoleOwner
+	return repo
 }

--- a/pkg/auth/domain/repositories/repositories.go
+++ b/pkg/auth/domain/repositories/repositories.go
@@ -90,6 +90,14 @@ type AccountRepository interface {
 	// SaveMember persists a membership between an account and an agent with a role.
 	SaveMember(ctx context.Context, accountID, agentID, roleID string) error
 
+	// RemoveMember revokes an agent's membership in an account. It is a
+	// single atomic delete, so callers never need a delete-all-then-reinsert
+	// rewrite to change a membership set — such a rewrite leaves a window in
+	// which a valid membership is invisible, and authentication refuses
+	// sessions scoped to accounts it cannot see. Removing a membership that
+	// does not exist is not an error.
+	RemoveMember(ctx context.Context, accountID, agentID string) error
+
 	// FindAll retrieves Account aggregates with cursor-based pagination.
 	FindAll(ctx context.Context, cursor string, limit int) (*PaginatedResponse[*entities.Account], error)
 }

--- a/pkg/auth/features/authenticated_request_identity.feature
+++ b/pkg/auth/features/authenticated_request_identity.feature
@@ -94,6 +94,21 @@ Feature: An authenticated request carries the caller's active account
       And no identity is attached to the request
       And the stored session for "orphan" is still active
 
+    @decision
+    Scenario: A session is refused once its membership is revoked
+      # The session records its account at sign-in and never revisits it, so
+      # without this the agent keeps acting in an account they were removed
+      # from until the session expires. Coded apart from an unscoped session
+      # because here signing in again does help: the next session is scoped to
+      # an account they still belong to.
+      Given "ada" has signed in and holds a session cookie
+      When "ada" is removed from the account "ada-personal"
+      And "ada" calls the protected endpoint
+      Then the request is rejected as unauthenticated
+      And the refusal is coded "account_access_revoked"
+      And no identity is attached to the request
+      And the stored session for "ada" is still active
+
     Scenario: A revoked session yields no identity
       Given "ada" has signed in and holds a session cookie
       And that session has been revoked

--- a/pkg/auth/infrastructure/database/gorm/repositories.go
+++ b/pkg/auth/infrastructure/database/gorm/repositories.go
@@ -135,6 +135,12 @@ func (r *accountRepository) SaveMember(ctx context.Context, accountID, agentID, 
 	return r.db.WithContext(ctx).Save(member).Error
 }
 
+func (r *accountRepository) RemoveMember(ctx context.Context, accountID, agentID string) error {
+	return r.db.WithContext(ctx).
+		Where("account_id = ? AND agent_id = ?", accountID, agentID).
+		Delete(&models.AccountMemberModel{}).Error
+}
+
 func (r *accountRepository) FindByID(ctx context.Context, id string) (*entities.Account, error) {
 	var m models.AccountModel
 	if err := r.db.WithContext(ctx).Where("id = ?", id).First(&m).Error; err != nil {

--- a/pkg/auth/infrastructure/http/middleware.go
+++ b/pkg/auth/infrastructure/http/middleware.go
@@ -3,6 +3,7 @@ package authhttp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -33,6 +34,42 @@ var (
 // A session that is not scoped to an account is treated as unauthenticated.
 // Sessions stored before sessions carried an account are all unscoped, and
 // there is no backfill, so their holders are refused once and sign in again.
+//
+// # Telling the 401s apart
+//
+// Three refusals share the 401 status and need opposite handling, so two of
+// them carry a "code" field in the JSON body. A client that treats every 401
+// the same will either loop forever or give up when retrying would have
+// worked.
+//
+//	code                    meaning                        what the client should do
+//	----------------------  -----------------------------  --------------------------------
+//	(none)                  no session, or it expired      sign in again
+//	                        or was revoked
+//	unscoped_session        the agent has no active        do NOT retry sign-in; it
+//	                        account to act in              produces another unscoped
+//	                        session. Surface it.
+//	account_access_revoked  the agent was removed from     retry sign-in; it MAY recover.
+//	                        the session's account          The next session is scoped to
+//	                                                       an account they still belong
+//	                                                       to — if they have one. If the
+//	                                                       retry answers unscoped_session,
+//	                                                       that is the terminal state.
+//
+// An account_access_revoked refusal can be transient. It is recomputed per
+// request against live memberships, so a non-transactional membership rewrite,
+// replica lag, or an asynchronous projection can briefly hide a valid
+// membership. The session is deliberately not revoked, so it starts working
+// again by itself once the membership is visible. Treat a single refusal as a
+// signal, not as proof the access is gone — and prefer
+// AccountRepository.RemoveMember, whose single-row delete has no such window,
+// over rewriting a membership set.
+//
+// The check is skipped entirely when memberships cannot be read — no account
+// repository is configured, or the lookup failed. That is deliberate, so a
+// database blip cannot log every user out at once, but it means a persistent
+// lookup failure silently disables revocation. The skip is logged; alarm on a
+// sustained rate if you rely on this enforcement.
 func RequireAuth(
 	sm session.SessionManager,
 	as application.AuthenticationService,
@@ -47,6 +84,14 @@ func RequireAuth(
 
 			sessionInfo, err := as.ValidateSession(r.Context(), sessionData.SessionID)
 			if err != nil {
+				// The session names an account the agent has since been
+				// removed from. Coded separately because signing in again
+				// does resolve it — the next session is scoped to an account
+				// they still belong to.
+				if errors.Is(err, application.ErrSessionAccountRevoked) {
+					writeJSONErrorCode(w, http.StatusUnauthorized, "not authenticated", "account_access_revoked")
+					return
+				}
 				writeJSONError(w, http.StatusUnauthorized, "not authenticated")
 				return
 			}

--- a/pkg/auth/infrastructure/http/middleware_test.go
+++ b/pkg/auth/infrastructure/http/middleware_test.go
@@ -715,3 +715,42 @@ func TestRequireAuth_UnscopedSession_IsDistinguishable(t *testing.T) {
 		t.Error("an expired session must not report itself as unscoped")
 	}
 }
+
+// Signing in again DOES resolve a revoked membership — the next session is
+// scoped to an account the agent still belongs to — so this must not be
+// confused with unscoped_session, where signing in again never helps.
+func TestRequireAuth_RevokedMembership_IsCodedSeparately(t *testing.T) {
+	t.Parallel()
+
+	store := sessions.NewCookieStore([]byte("test-secret-key-32-bytes-long!!!"))
+	sm := session.NewGorillaSessionManager("test-session", store, session.DefaultSessionOptions())
+
+	svc := &mockAuthService{
+		validateSessFunc: func(_ context.Context, _ string) (*application.SessionInfo, error) {
+			return nil, application.ErrSessionAccountRevoked
+		},
+	}
+
+	reached := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	authhttp.RequireAuth(sm, svc)(next).ServeHTTP(w, requestWithSessionCookie(t, sm, "sess-1", "agent-1"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if reached {
+		t.Error("handler ran for a session whose membership was revoked")
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["code"] != "account_access_revoked" {
+		t.Errorf("code = %q, want %q", body["code"], "account_access_revoked")
+	}
+}

--- a/pkg/auth/infrastructure/http/switch_account_test.go
+++ b/pkg/auth/infrastructure/http/switch_account_test.go
@@ -31,6 +31,7 @@ func (m *mockAccountRepo) FindPersonalByMember(_ context.Context, _ string) (*en
 	return nil, nil
 }
 func (m *mockAccountRepo) SaveMember(_ context.Context, _, _, _ string) error { return nil }
+func (m *mockAccountRepo) RemoveMember(_ context.Context, _, _ string) error  { return nil }
 func (m *mockAccountRepo) FindAll(_ context.Context, _ string, _ int) (*repositories.PaginatedResponse[*entities.Account], error) {
 	return nil, nil
 }


### PR DESCRIPTION
Closes #70

A session records its account at sign-in and never revisits it. An agent removed from that account kept authorizing writes into it until the session expired — `ValidateSession` reported a stale `ActiveAccountID` while the membership list it computes alongside no longer contained that account. The identity was internally inconsistent, and the stale half was the one authorization actually used.

## What changed

`ValidateSession` refuses with `ErrSessionAccountRevoked` when the session's account is no longer among the agent's live memberships. `RequireAuth` answers 401 with `code: "account_access_revoked"`.

**A correction was needed to make the check possible at all.** `AccountIDs` was seeded with the session's own account *before* the repository was consulted, so the account was present by construction and the comparison could never have failed. The list is now built from the repository alone, with the session's account prepended afterwards — same contents, same ordering guarantee, same assertions.

**The check runs before `Touch`/`Save`.** A refused request performs no writes and skips the permissions lookup. This matters beyond tidiness: refusals never converge on their own — a polling client re-fires them every request — so a refused session must not keep looking freshly used to anyone auditing last-accessed times.

## The same hole existed on the JWT side

`IssueIdentityToken` fetched the agent's memberships and never checked the caller-supplied `activeAccountID` against them. A removed agent could mint a **fresh** token — through `RefreshIdentityToken`, with no re-authentication — still scoped to the account they had just lost. Fixing only the session path would have left #70 fully reproducible on every JWT endpoint, and unlike the session it would never even converge at expiry.

`RequireJWT` itself is deliberately unchanged: it reads claims, not the session row, and a membership check there would mean a database read per request, defeating stateless token auth. The controls are validation at issuance plus short token lifetimes.

## `AccountRepository.RemoveMember`

Revoking a membership previously required raw SQL, because the repository exposed `SaveMember` and no removal — `Account.RemoveMember` exists on the entity but nothing persisted it. The common delete-all-then-reinsert rewrite leaves a window in which a valid membership is invisible, and this change turns that window into a spurious 401 that signs a real user out. A single-row delete has none.

## Deliberate decisions

| Decision | Choice | Why |
|---|---|---|
| Refusal signal | Its own code | Re-login **does** fix this, and **never** fixes `unscoped_session` — opposite client actions |
| Session state | Not revoked | Detection stays a pure read; the session recovers by itself if the membership reappears |
| Untrusted membership list | **Fail open** | With no account repository the list is always empty, so failing closed would refuse everything; and callers map a validation error to 401, so a database blip would log out every user at once |
| Deactivated accounts | Out of scope | That is #71, a separate policy question spanning sign-in, switch, and request paths |

The fail-open is a real trade-off: a persistent lookup failure silently disables revocation. The skip is logged; the middleware docs say to alarm on a sustained rate if you rely on this enforcement.

## Breaking change

`AccountRepository` gains `RemoveMember`. Downstream implementors must add it. Bundling it now, right after #69's five, is likely kinder than a second wave later.

## Testing

29 acceptance scenarios / 202 steps under godog against the real service, real middleware and the real OAuth callback, plus new unit tests covering: refusal, the session staying active **and untouched**, recovery when the membership reappears, both fail-open paths, and both JWT issuance paths.

Verified by mutation rather than assertion — disabling the check fails exactly the new acceptance scenario and the new unit test, and nothing else. `go test -race ./...` passes repo-wide; `golangci-lint` clean on `pkg/auth`.

## Related

- #71 — a member can still *switch into* a deactivated account; `assertMember` does not check `Active()`.
- #72 — this adds a second read-after-write dependency (issuance now reads the membership row written moments earlier in the same request), which strengthens the case for fixing it.
