### PR TITLE
fix(auth): treat account deactivation as an authorization boundary

### DIFF
--- a/pkg/auth/acceptance_test.go
+++ b/pkg/auth/acceptance_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -186,6 +187,7 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the session info reports account "([^"]*)"$`, w.sessionInfoReportsAccount)
 	sc.Step(`^the session is still scoped to account "([^"]*)"$`, w.storedSessionStillScopedTo)
 	sc.Step(`^the request is rejected because "([^"]*)" is not a member of "([^"]*)"$`, w.rejectedAsNotMember)
+	sc.Step(`^the request is rejected because the account "([^"]*)" is deactivated$`, w.rejectedAsDeactivated)
 	sc.Step(`^the request succeeds$`, w.requestSucceeds)
 	sc.Step(`^the request is rejected as unauthenticated$`, w.requestRejectedUnauthenticated)
 	sc.Step(`^the refusal is coded "([^"]*)"$`, w.refusalIsCoded)
@@ -953,6 +955,16 @@ func (w *world) rejectedAsNotMember(agentID, accountID string) error {
 	}
 	if !isNotMemberError(w.lastErr) {
 		return fmt.Errorf("got error %v, want ErrAccountNotMember", w.lastErr)
+	}
+	return nil
+}
+
+func (w *world) rejectedAsDeactivated(accountID string) error {
+	if w.lastErr == nil {
+		return fmt.Errorf("expected the request to be refused for deactivated account %s, got no error", accountID)
+	}
+	if !errors.Is(w.lastErr, application.ErrAccountDeactivated) {
+		return fmt.Errorf("got error %v, want ErrAccountDeactivated", w.lastErr)
 	}
 	return nil
 }

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -35,6 +35,8 @@ var (
 	ErrPasswordCredentialMissing    = errors.New("authentication: password credential not found for agent")
 	ErrAccountNotMember             = errors.New("authentication: agent is not a member of the account")
 	ErrSessionAccountRevoked        = errors.New("authentication: session is scoped to an account the agent no longer belongs to")
+	ErrAccountDeactivated           = errors.New("authentication: account is deactivated")
+	ErrSessionAccountDeactivated    = errors.New("authentication: session is scoped to a deactivated account")
 	// ErrJWTServiceNotConfigured is returned by RefreshIdentityToken when
 	// no JWTService is wired. Distinct from IssueIdentityToken's
 	// ("", nil) shape because refresh's sole purpose is to mint a token —
@@ -538,6 +540,22 @@ func (s *DefaultAuthenticationService) assertMember(ctx context.Context, account
 	if role == "" {
 		return fmt.Errorf("%w: agent %s in account %s", ErrAccountNotMember, agentID, accountID)
 	}
+
+	// Membership alone is not access. Sign-in already passes over a
+	// deactivated account, so accepting one here would leave the only route
+	// into a suspended tenant open — a member could still switch into it and
+	// keep working. Deactivation is an authorization boundary, not just a
+	// sign-in filter.
+	account, err := s.accounts.FindByID(ctx, accountID)
+	if err != nil {
+		return fmt.Errorf("failed to load account: %w", err)
+	}
+	if account == nil {
+		return fmt.Errorf("%w: account %s not found", ErrAccountNotMember, accountID)
+	}
+	if !account.Active() {
+		return fmt.Errorf("%w: account %s", ErrAccountDeactivated, accountID)
+	}
 	return nil
 }
 
@@ -600,7 +618,11 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 	// lookup failed. The list is then not evidence of anything and must not be
 	// used to refuse: with no repository it is always empty, and callers turn
 	// a validation error into 401, so a database blip would log everyone out.
-	var memberships []string
+	// memberships is every account the agent belongs to; active is the subset
+	// they may actually act in. Keeping both apart lets a refusal say which
+	// happened — removed from the account, or the account was suspended —
+	// rather than reporting a suspension as a revoked membership.
+	var memberships, active []string
 	membershipsKnown := false
 	if s.accounts != nil {
 		accounts, listErr := s.accounts.FindByMember(ctx, session.AgentID())
@@ -616,6 +638,9 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 				}
 				seen[account.GetID()] = true
 				memberships = append(memberships, account.GetID())
+				if account.Active() {
+					active = append(active, account.GetID())
+				}
 			}
 		}
 	}
@@ -632,10 +657,20 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 	// their own — a polling client re-fires this on every request — so a
 	// refused session must not keep looking freshly used to anyone auditing
 	// last-accessed times.
-	if membershipsKnown && session.AccountID() != "" && !slices.Contains(memberships, session.AccountID()) {
-		s.logger.Warn(ctx, "auth: session scoped to a revoked membership",
-			"agent_id", session.AgentID(), "session_id", session.GetID(), "account_id", session.AccountID())
-		return nil, ErrSessionAccountRevoked
+	if membershipsKnown && session.AccountID() != "" {
+		switch {
+		case !slices.Contains(memberships, session.AccountID()):
+			s.logger.Warn(ctx, "auth: session scoped to a revoked membership",
+				"agent_id", session.AgentID(), "session_id", session.GetID(), "account_id", session.AccountID())
+			return nil, ErrSessionAccountRevoked
+		case !slices.Contains(active, session.AccountID()):
+			// Still a member, but the account was suspended. Sign-in refuses
+			// to scope a new session to one, so letting an existing session
+			// carry on would make suspension depend on when you logged in.
+			s.logger.Warn(ctx, "auth: session scoped to a deactivated account",
+				"agent_id", session.AgentID(), "session_id", session.GetID(), "account_id", session.AccountID())
+			return nil, ErrSessionAccountDeactivated
+		}
 	}
 
 	// Touch the session to update last accessed time
@@ -656,12 +691,14 @@ func (s *DefaultAuthenticationService) ValidateSession(ctx context.Context, sess
 	}
 
 	// Session's own account first, then the rest, so the ordering a caller
-	// sees does not depend on repository order.
+	// sees does not depend on repository order. Only active accounts are
+	// listed: an account switcher reading this identity must not offer a
+	// suspended tenant that switching into would be refused.
 	accountIDs := []string{}
 	if session.AccountID() != "" {
 		accountIDs = append(accountIDs, session.AccountID())
 	}
-	for _, id := range memberships {
+	for _, id := range active {
 		if id != session.AccountID() {
 			accountIDs = append(accountIDs, id)
 		}

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -2054,6 +2055,7 @@ func TestDefaultAuthenticationService_CreateSession_ScopesToAccount(t *testing.T
 	ctx := context.Background()
 
 	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "acct-1", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
 
 	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
@@ -2142,7 +2144,9 @@ func TestDefaultAuthenticationService_ScopeSessionToAccount(t *testing.T) {
 	ctx := context.Background()
 
 	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "acct-1", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+	deps.accounts.accounts["acct-2"] = newScopedAccount(t, "acct-2", "acct-2", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-2:agent-1"] = entities.RoleMember
 
 	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
@@ -2169,6 +2173,7 @@ func TestDefaultAuthenticationService_ScopeSessionToAccount_RejectsNonMember(t *
 	ctx := context.Background()
 
 	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "acct-1", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
 
 	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
@@ -2243,6 +2248,7 @@ func TestDefaultAuthenticationService_ValidateSession_MembershipOutageDegrades(t
 	ctx := context.Background()
 
 	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "acct-1", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
 
 	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
@@ -2378,6 +2384,7 @@ func TestDefaultAuthenticationService_ValidateSession_MembershipOutageDoesNotRef
 	ctx := context.Background()
 
 	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "acct-1", entities.AccountTypeOrganization, true)
 	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
 
 	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
@@ -2490,4 +2497,114 @@ func newTokenAccountRepo(t *testing.T) *mockAccountRepo {
 	repo.accounts["account-1"] = newScopedAccount(t, "account-1", "Alice", entities.AccountTypePersonal, true)
 	repo.memberRoles["account-1:agent-1"] = entities.RoleOwner
 	return repo
+}
+
+// --- Deactivated accounts are an authorization boundary (#71) ---
+
+// Sign-in already passes over a deactivated account. Accepting one here left
+// the only route into a suspended tenant open: a member could still switch
+// into it and keep working.
+func TestDefaultAuthenticationService_ScopeSessionToAccount_RefusesDeactivated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	deps.accounts.accounts["acct-2"] = newScopedAccount(t, "acct-2", "Suspended", entities.AccountTypeOrganization, false)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+	deps.accounts.memberRoles["acct-2:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	err = svc.ScopeSessionToAccount(ctx, session.GetID(), "acct-2")
+	if !errors.Is(err, application.ErrAccountDeactivated) {
+		t.Fatalf("ScopeSessionToAccount() error = %v, want ErrAccountDeactivated", err)
+	}
+
+	stored, _ := deps.sessions.FindByID(ctx, session.GetID())
+	if stored.AccountID() != "acct-1" {
+		t.Errorf("AccountID() = %q, want it unchanged at %q", stored.AccountID(), "acct-1")
+	}
+}
+
+func TestDefaultAuthenticationService_CreateSession_RefusesDeactivatedAccount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Suspended", entities.AccountTypeOrganization, false)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	_, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if !errors.Is(err, application.ErrAccountDeactivated) {
+		t.Fatalf("CreateSession() error = %v, want ErrAccountDeactivated", err)
+	}
+	if len(deps.sessions.sessions) != 0 {
+		t.Errorf("expected no stored session, got %d", len(deps.sessions.sessions))
+	}
+}
+
+// Suspending an account must not depend on when its members last logged in.
+// Reported apart from revocation because the agent is still a member and the
+// remedy is an operator reactivating the account, not the user retrying.
+func TestDefaultAuthenticationService_ValidateSession_RefusesDeactivatedAccount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	account := newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.accounts["acct-1"] = account
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	if err := account.Deactivate(); err != nil {
+		t.Fatalf("Deactivate() error: %v", err)
+	}
+
+	_, err = svc.ValidateSession(ctx, session.GetID())
+	if !errors.Is(err, application.ErrSessionAccountDeactivated) {
+		t.Fatalf("ValidateSession() error = %v, want ErrSessionAccountDeactivated", err)
+	}
+	if errors.Is(err, application.ErrSessionAccountRevoked) {
+		t.Error("a suspended account must not be reported as a revoked membership")
+	}
+}
+
+// A switcher reading the identity must not offer a tenant that switching into
+// would be refused.
+func TestDefaultAuthenticationService_ValidateSession_OmitsDeactivatedFromAccountIDs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	deps.accounts.accounts["acct-2"] = newScopedAccount(t, "acct-2", "Suspended", entities.AccountTypeOrganization, false)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+	deps.accounts.memberRoles["acct-2:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "192.168.1.1", "Mozilla/5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+	session.ClearUncommittedEvents()
+
+	info, err := svc.ValidateSession(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("ValidateSession() error: %v", err)
+	}
+	if slices.Contains(info.AccountIDs, "acct-2") {
+		t.Errorf("AccountIDs = %v, want the deactivated acct-2 omitted", info.AccountIDs)
+	}
+	if !slices.Contains(info.AccountIDs, "acct-1") {
+		t.Errorf("AccountIDs = %v, want it to include acct-1", info.AccountIDs)
+	}
 }

--- a/pkg/auth/application/invite_service.go
+++ b/pkg/auth/application/invite_service.go
@@ -201,6 +201,11 @@ func (s *InviteService) AcceptInvite(ctx context.Context, token string, userInfo
 	if account == nil {
 		return nil, nil, nil, fmt.Errorf("invite: account %s not found", invite.AccountID())
 	}
+	// An invite issued before the account was suspended would otherwise be a
+	// way into it, which is the one route deactivation must not leave open.
+	if !account.Active() {
+		return nil, nil, nil, fmt.Errorf("%w: account %s", ErrAccountDeactivated, invite.AccountID())
+	}
 
 	if err = account.AddMember(agent.GetID(), invite.RoleID()); err != nil {
 		return nil, nil, nil, fmt.Errorf("invite: failed to add member to account: %w", err)

--- a/pkg/auth/application/invite_service_test.go
+++ b/pkg/auth/application/invite_service_test.go
@@ -497,3 +497,36 @@ func TestInviteService_AcceptInvite_EmptyDisplayName_KeepsEmail(t *testing.T) {
 		t.Errorf("agent Name() = %q, want %q", agent.Name(), "alice@example.com")
 	}
 }
+
+// An invite issued before the account was suspended would otherwise be a way
+// into it — the one route deactivation must not leave open (#71).
+func TestInviteService_AcceptInvite_RefusesDeactivatedAccount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newInviteTestService()
+	setupAccountWithAdmin(deps)
+
+	_, token, err := svc.CreateInvite(ctx, "account-1", "alice@example.com", entities.RoleMember, "admin-agent")
+	if err != nil {
+		t.Fatalf("CreateInvite() error: %v", err)
+	}
+
+	account := deps.accounts.accounts["account-1"]
+	if account == nil {
+		t.Fatal("expected account-1 in the fixture")
+	}
+	if err := account.Deactivate(); err != nil {
+		t.Fatalf("Deactivate() error: %v", err)
+	}
+
+	_, _, _, err = svc.AcceptInvite(ctx, token, application.UserInfo{
+		ProviderUserID: "google-user-alice",
+		Email:          "alice@example.com",
+		DisplayName:    "Alice Smith",
+		Provider:       "google",
+	})
+	if !errors.Is(err, application.ErrAccountDeactivated) {
+		t.Fatalf("AcceptInvite() error = %v, want ErrAccountDeactivated", err)
+	}
+}

--- a/pkg/auth/features/authenticated_request_identity.feature
+++ b/pkg/auth/features/authenticated_request_identity.feature
@@ -109,6 +109,19 @@ Feature: An authenticated request carries the caller's active account
       And no identity is attached to the request
       And the stored session for "ada" is still active
 
+    @decision
+    Scenario: A session is refused once its account is deactivated
+      # Suspending an account must not depend on when its members last logged
+      # in. Coded apart from a revoked membership because the agent is still a
+      # member: the remedy is an operator reactivating the account, not the
+      # user signing in again.
+      Given "ada" has signed in and holds a session cookie
+      When the account "ada-personal" is deactivated
+      And "ada" calls the protected endpoint
+      Then the request is rejected as unauthenticated
+      And the refusal is coded "account_deactivated"
+      And no identity is attached to the request
+
     Scenario: A revoked session yields no identity
       Given "ada" has signed in and holds a session cookie
       And that session has been revoked

--- a/pkg/auth/features/session_account_scoping.feature
+++ b/pkg/auth/features/session_account_scoping.feature
@@ -93,6 +93,18 @@ Feature: An auth session is scoped to an account when the agent signs in
       And that session is not scoped to any account
 
     @security
+    Scenario: A session is never scoped to a deactivated account
+      # Sign-in already passes over a deactivated account. Accepting one when
+      # the caller names it explicitly would leave the only route into a
+      # suspended tenant open.
+      Given an organization account "acme" exists
+      And "ada" is also a "member" of the organization account "acme"
+      And the account "acme" is deactivated
+      When a session is requested for "ada" scoped to account "acme"
+      Then the request is rejected because the account "acme" is deactivated
+      And no session is stored for "ada"
+
+    @security
     Scenario: A session is never scoped to an account the agent does not belong to
       Given an organization account "acme" exists
       And "ada" is not a member of "acme"

--- a/pkg/auth/infrastructure/http/middleware.go
+++ b/pkg/auth/infrastructure/http/middleware.go
@@ -55,6 +55,12 @@ var (
 //	                                                       to — if they have one. If the
 //	                                                       retry answers unscoped_session,
 //	                                                       that is the terminal state.
+//	account_deactivated     the agent is still a member,   retry sign-in only helps if
+//	                        but the account is suspended   they belong to another ACTIVE
+//	                                                       account. Otherwise this is an
+//	                                                       operator problem — reactivate
+//	                                                       the account. Say so; do not
+//	                                                       tell the user to sign in again.
 //
 // An account_access_revoked refusal can be transient. It is recomputed per
 // request against live memberships, so a non-transactional membership rewrite,
@@ -90,6 +96,14 @@ func RequireAuth(
 				// they still belong to.
 				if errors.Is(err, application.ErrSessionAccountRevoked) {
 					writeJSONErrorCode(w, http.StatusUnauthorized, "not authenticated", "account_access_revoked")
+					return
+				}
+				// Distinct from revocation: the agent is still a member, the
+				// account itself is suspended. Signing in again cannot help
+				// unless they belong to another active account, and an
+				// operator debugging this needs to know which happened.
+				if errors.Is(err, application.ErrSessionAccountDeactivated) {
+					writeJSONErrorCode(w, http.StatusUnauthorized, "not authenticated", "account_deactivated")
 					return
 				}
 				writeJSONError(w, http.StatusUnauthorized, "not authenticated")


### PR DESCRIPTION
Closes #71

**Layer 1 of 3** — stack #78. Base: `main`.

Sign-in passed over a deactivated account, but `assertMember` only checked that a membership row existed. Two contradictory policies in the same file, and the gap was reachable: members could no longer *log in* to a suspended account, but anyone holding a session could still **switch into it and keep reading and writing its data**. Suspending an account did not suspend access to it.

## The policy, stated once

Deactivation is an **authorization boundary**, not a sign-in filter.

- `assertMember` requires the account to be active, so neither `CreateSession` nor `ScopeSessionToAccount` will scope a session to a suspended tenant.
- `ValidateSession` refuses an existing session whose account has since been deactivated — suspension must not depend on when its members last logged in.
- `AcceptInvite` refuses a deactivated account. An invite issued before suspension was otherwise a way straight back in, which is the one route this must not leave open.
- The identity's account list carries only active accounts, so a switcher cannot offer a tenant that switching into would be refused.

## A fourth 401 code, deliberately

`account_deactivated` is separate from `account_access_revoked` because the agent is **still a member** and the remedy is different: an operator reactivates the account. Telling the user to sign in again — which `account_access_revoked` means — is wrong here and sends them round a loop that cannot resolve.

## Cost and edges

One `FindByID` per scope check. A membership row pointing at an account that does not exist is treated as no membership.

## Testing

Four unit tests plus two acceptance scenarios (31 scenarios / 219 steps total). Verified by mutation: disabling both checks fails exactly three unit tests and both new scenarios, and nothing else.
