### PR TITLE
fix(auth): let a sign-in vouch for the account it just resolved

### DIFF
--- a/pkg/auth/application/account_trust.go
+++ b/pkg/auth/application/account_trust.go
@@ -1,0 +1,37 @@
+package application
+
+// AccountTrustOption tells an operation how much to trust the account ID it
+// was handed.
+type AccountTrustOption func(*accountTrust)
+
+type accountTrust struct {
+	verified bool
+}
+
+// AccountAlreadyVerified declares that the account was resolved by this same
+// request, from a path that already established the agent's membership and
+// that the account is active — so the operation may skip re-reading it.
+//
+// Pass it only from a sign-in path that resolved the account itself:
+// FindOrCreateAgent, VerifyPassword and AcceptInvite all qualify. Do not pass
+// it for an account that arrived from a client, which is exactly what the
+// check exists to catch.
+//
+// This is not only an optimisation. Sign-in writes the membership row and then
+// verifies it moments later in the same request; on a read replica or an
+// asynchronous read model that row may not be visible yet, so a brand-new user
+// could fail their very first sign-in. Vouching removes the race along with
+// the redundant read.
+func AccountAlreadyVerified() AccountTrustOption {
+	return func(t *accountTrust) { t.verified = true }
+}
+
+func newAccountTrust(opts []AccountTrustOption) accountTrust {
+	var t accountTrust
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&t)
+		}
+	}
+	return t
+}

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -162,7 +162,7 @@ type AuthenticationService interface {
 
 	// IssueIdentityToken issues a signed JWT for the given agent.
 	// Returns ("", nil) if no JWTService is configured.
-	IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error)
+	IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string, opts ...AccountTrustOption) (string, error)
 
 	// RefreshIdentityToken re-snapshots claims for an existing agent and
 	// returns a freshly signed JWT. Re-runs the ClaimsEnricher and
@@ -191,7 +191,7 @@ type AuthenticationService interface {
 	// stored unscoped and sign-in still succeeds, but every authenticated
 	// request made with it is refused. Passing an account the agent is not a
 	// member of returns ErrAccountNotMember and stores nothing.
-	CreateSession(ctx context.Context, agentID string, accountID string, credentialID string, ipAddress string, userAgent string, duration time.Duration) (*entities.AuthSession, error)
+	CreateSession(ctx context.Context, agentID string, accountID string, credentialID string, ipAddress string, userAgent string, duration time.Duration, opts ...AccountTrustOption) (*entities.AuthSession, error)
 
 	// ScopeSessionToAccount re-scopes a stored session to another account the
 	// agent belongs to, and persists it. Returns ErrAccountNotMember if the
@@ -462,8 +462,8 @@ func (s *DefaultAuthenticationService) FindOrCreateAgent(ctx context.Context, us
 
 // CreateSession creates an authenticated session for an agent, scoped to
 // accountID. See the AuthenticationService interface for the contract.
-func (s *DefaultAuthenticationService) CreateSession(ctx context.Context, agentID string, accountID string, credentialID string, ipAddress string, userAgent string, duration time.Duration) (*entities.AuthSession, error) {
-	if accountID != "" {
+func (s *DefaultAuthenticationService) CreateSession(ctx context.Context, agentID string, accountID string, credentialID string, ipAddress string, userAgent string, duration time.Duration, opts ...AccountTrustOption) (*entities.AuthSession, error) {
+	if accountID != "" && !newAccountTrust(opts).verified {
 		if err := s.assertMember(ctx, accountID, agentID); err != nil {
 			return nil, err
 		}
@@ -777,7 +777,7 @@ func (s *DefaultAuthenticationService) RevokeAllSessions(ctx context.Context, ag
 // login. When a ClaimsEnricher is wired its result is passed as extras
 // to JWTService.IssueToken; an enricher error fails token issuance
 // (contrast SubscriptionService, which is fail-open).
-func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error) {
+func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string, opts ...AccountTrustOption) (string, error) {
 	if s.jwtService == nil {
 		return "", nil
 	}
@@ -800,7 +800,7 @@ func (s *DefaultAuthenticationService) IssueIdentityToken(ctx context.Context, a
 		//
 		// Only enforced when an account repository exists. Without one the
 		// list is always empty and this would refuse every token.
-		if activeAccountID != "" && !accountsContain(accounts, activeAccountID) {
+		if activeAccountID != "" && !newAccountTrust(opts).verified && !accountsContain(accounts, activeAccountID) {
 			return "", fmt.Errorf("%w: agent %s in account %s", ErrAccountNotMember, agent.GetID(), activeAccountID)
 		}
 	}

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -2608,3 +2608,73 @@ func TestDefaultAuthenticationService_ValidateSession_OmitsDeactivatedFromAccoun
 		t.Errorf("AccountIDs = %v, want it to include acct-1", info.AccountIDs)
 	}
 }
+
+// --- The caller can vouch for an account it just resolved (#72) ---
+
+// Sign-in writes the membership row and verifies it moments later in the same
+// request. On a read replica or an asynchronous read model that row may not be
+// visible yet, which would fail a brand-new user's very first sign-in. An
+// unseeded membership stands in for that invisibility.
+func TestDefaultAuthenticationService_CreateSession_VouchedAccountSkipsTheReRead(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	// Deliberately no membership row: the write has not become visible.
+
+	if _, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour); !errors.Is(err, application.ErrAccountNotMember) {
+		t.Fatalf("unvouched CreateSession() = %v, want ErrAccountNotMember", err)
+	}
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour,
+		application.AccountAlreadyVerified())
+	if err != nil {
+		t.Fatalf("vouched CreateSession() error: %v", err)
+	}
+	if session.AccountID() != "acct-1" {
+		t.Errorf("AccountID() = %q, want %q", session.AccountID(), "acct-1")
+	}
+	if len(deps.sessions.sessions) != 1 {
+		t.Errorf("expected 1 stored session, got %d", len(deps.sessions.sessions))
+	}
+}
+
+// Vouching is for the sign-in path only. An account that arrived from a client
+// is exactly what the check exists to catch, so the default stays strict.
+func TestDefaultAuthenticationService_CreateSession_UnvouchedStillChecked(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps := newTestService()
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.memberRoles["acct-1:someone-else"] = entities.RoleOwner
+
+	_, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour)
+	if !errors.Is(err, application.ErrAccountNotMember) {
+		t.Fatalf("CreateSession() = %v, want ErrAccountNotMember", err)
+	}
+	if len(deps.sessions.sessions) != 0 {
+		t.Errorf("expected no stored session, got %d", len(deps.sessions.sessions))
+	}
+}
+
+func TestIssueIdentityToken_VouchedAccountSkipsTheReRead(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	jwtSvc := &mockJWTService{}
+	svc := application.NewDefaultAuthenticationService(
+		application.OAuthProviderRegistry{},
+		newMockAgentRepo(), newMockCredentialRepo(), newMockSessionRepo(), newMockAccountRepo(),
+		application.WithJWTService(jwtSvc),
+	)
+	agent, _ := new(entities.Agent).With("agent-1", "Alice", entities.AgentTypePerson)
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1"); !errors.Is(err, application.ErrAccountNotMember) {
+		t.Fatalf("unvouched IssueIdentityToken() = %v, want ErrAccountNotMember", err)
+	}
+
+	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1", application.AccountAlreadyVerified()); err != nil {
+		t.Fatalf("vouched IssueIdentityToken() error: %v", err)
+	}
+}

--- a/pkg/auth/infrastructure/http/handlers.go
+++ b/pkg/auth/infrastructure/http/handlers.go
@@ -194,9 +194,15 @@ func (h *AuthHandlers) Callback(w http.ResponseWriter, r *http.Request) {
 	if account != nil {
 		accountID = account.GetID()
 	}
+	// The account came from AcceptInvite or FindOrCreateAgent moments ago, so
+	// it is a member's and it is active by construction. Vouching for it skips
+	// a redundant read — and avoids failing a brand-new user's first sign-in
+	// on a read model that has not caught up with the membership row this
+	// same request just wrote.
 	authSession, err := h.cfg.AuthService.CreateSession(
 		ctx, agent.GetID(), accountID, credential.GetID(),
 		ipAddress, userAgent, h.cfg.SessionDuration,
+		application.AccountAlreadyVerified(),
 	)
 	if err != nil {
 		h.cfg.Logger.Error(ctx, "session creation failed", "error", err)
@@ -229,7 +235,7 @@ func (h *AuthHandlers) Callback(w http.ResponseWriter, r *http.Request) {
 		h.cfg.Logger.Warn(ctx, "sign-in resolved no active account; session is unscoped and authenticated requests will be refused",
 			"agent_id", agent.GetID())
 	} else {
-		tokenString, issueErr := h.cfg.AuthService.IssueIdentityToken(ctx, agent, accountID)
+		tokenString, issueErr := h.cfg.AuthService.IssueIdentityToken(ctx, agent, accountID, application.AccountAlreadyVerified())
 		if issueErr != nil {
 			h.cfg.Logger.Warn(ctx, "failed to issue identity token", "error", issueErr)
 		} else if tokenString != "" {

--- a/pkg/auth/infrastructure/http/handlers_test.go
+++ b/pkg/auth/infrastructure/http/handlers_test.go
@@ -84,7 +84,7 @@ func (m *mockAuthService) FindOrCreateAgent(ctx context.Context, userInfo applic
 	return agent, cred, account, nil
 }
 
-func (m *mockAuthService) CreateSession(ctx context.Context, agentID, accountID, credentialID, ipAddress, userAgent string, duration time.Duration) (*entities.AuthSession, error) {
+func (m *mockAuthService) CreateSession(ctx context.Context, agentID, accountID, credentialID, ipAddress, userAgent string, duration time.Duration, _ ...application.AccountTrustOption) (*entities.AuthSession, error) {
 	if m.createSessionFunc != nil {
 		return m.createSessionFunc(ctx, agentID, accountID, credentialID, ipAddress, userAgent, duration)
 	}
@@ -131,7 +131,7 @@ func (m *mockAuthService) RefreshTokens(ctx context.Context, credentialID string
 	return &application.AuthResult{AccessToken: "new-token"}, nil
 }
 
-func (m *mockAuthService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string) (string, error) {
+func (m *mockAuthService) IssueIdentityToken(ctx context.Context, agent *entities.Agent, activeAccountID string, _ ...application.AccountTrustOption) (string, error) {
 	if m.issueIdentityTokenFunc != nil {
 		return m.issueIdentityTokenFunc(ctx, agent, activeAccountID)
 	}


### PR DESCRIPTION
Closes #72

**Layer 2 of 3** — stack #78. Base: `fix/71-deactivated-account-blocks-access` (#75).

`CreateSession` verifies the membership row that `FindOrCreateAgent` or `AcceptInvite` wrote moments earlier **in the same request**, and since #70 `IssueIdentityToken` re-reads it too. On a read replica or an asynchronous read model that row may not be visible yet, so a brand-new user could fail their very first sign-in with a 500 — a sign-up funnel failure that is hard to reproduce and easy to miss.

## The fix

Both operations accept `AccountAlreadyVerified()`, declaring that the account came from a path in this same request that already established membership *and* that the account is active. The sign-in callback passes it, so the redundant read disappears along with the race.

Everything else stays strict. An account that arrived from a client is exactly what the check exists to catch.

## Why this is only sound on top of #75

Every resolver that feeds the vouch must guarantee an **active** account. `FindOrCreateAgent` and `VerifyPassword` go through `resolveActiveAccount`; `AcceptInvite` did **not** check `Active()` until the layer below added it. Without #75, skipping the check here would have reopened the hole #71 closed — which is why that check went in the lower layer rather than this one.

## Breaking change

`CreateSession` and `IssueIdentityToken` gain a variadic `AccountTrustOption`. **Call sites are source-compatible**; implementors of `AuthenticationService` must add the parameter.

## Testing

Three unit tests covering the vouched path, the unvouched path staying strict, and the token equivalent. An unseeded membership stands in for the invisible write.
