### PR TITLE
feat(auth): persist the session lifecycle as events

### DIFF
--- a/pkg/auth/acceptance_test.go
+++ b/pkg/auth/acceptance_test.go
@@ -30,6 +30,7 @@ import (
 	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
 	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
 	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	esinfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
 )
 
 // TestAcceptance runs the Gherkin acceptance contract in features/ against the
@@ -92,6 +93,7 @@ type world struct {
 
 	sess          *entities.AuthSession
 	sessionEvents []esdomain.EventEnvelope[any]
+	eventStore    *esinfra.MemoryStore
 	reloaded      *entities.AuthSession
 	rebuilt       *entities.AuthSession
 	info          *application.SessionInfo
@@ -247,12 +249,17 @@ func (w *world) setup() error {
 	w.callbackCookies = nil
 	w.lastBody = nil
 
+	// A real event store, so session events are actually persisted and the
+	// rebuild scenario reads them back from storage rather than from the
+	// aggregate that produced them.
+	w.eventStore = esinfra.NewMemoryStore()
 	w.svc = application.NewDefaultAuthenticationService(
 		application.OAuthProviderRegistry{"google": w.provider},
 		w.agents, w.credentials, w.sessions, w.accounts,
 		application.WithPasswordCredentialRepository(w.passwords),
 		application.WithJWTService(w.jwtSvc),
 		application.WithBcryptCost(bcrypt.MinCost),
+		application.WithEventStore(w.eventStore),
 	)
 
 	// The real invite service, acting as the callback's InviteAcceptor, so the
@@ -780,13 +787,21 @@ func (w *world) sessionIsReloaded() error {
 // field assigned without an event shows up as a rebuild that lost the account.
 func (w *world) sessionIsRebuiltFromEvents() error {
 	ctx := context.Background()
-	if len(w.sessionEvents) == 0 {
-		return fmt.Errorf("session recorded no events to rebuild from")
+	// Read the events back from the store rather than from the aggregate that
+	// produced them, so this proves a real round-trip and not just that
+	// ApplyEvent mirrors RecordEvent.
+	stored, err := w.eventStore.GetEvents(ctx, w.sess.GetID())
+	if err != nil {
+		return fmt.Errorf("load session events: %w", err)
 	}
+	if len(stored) == 0 {
+		return fmt.Errorf("no session events were persisted for %s", w.sess.GetID())
+	}
+	w.sessionEvents = stored
 	rebuilt := &entities.AuthSession{}
 	if err := rebuilt.Restore(
 		w.sess.GetID(), "placeholder", "", "", "", "", false,
-		time.Time{}, time.Time{}, time.Time{}); err != nil {
+		time.Time{}, time.Time{}, time.Time{}, 0); err != nil {
 		return fmt.Errorf("prepare rebuild: %w", err)
 	}
 	for i, event := range w.sessionEvents {

--- a/pkg/auth/application/authentication_service.go
+++ b/pkg/auth/application/authentication_service.go
@@ -478,11 +478,36 @@ func (s *DefaultAuthenticationService) CreateSession(ctx context.Context, agentI
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
+	if err = s.commitSessionEvents(ctx, session); err != nil {
+		return nil, err
+	}
 	if err = s.sessions.Save(ctx, session); err != nil {
 		return nil, fmt.Errorf("failed to save session: %w", err)
 	}
 
 	return session, nil
+}
+
+// commitSessionEvents persists a session's uncommitted events through a unit
+// of work, so the authentication timeline — created, re-scoped, revoked — is
+// durable like every other aggregate's.
+//
+// Deliberately not called from ValidateSession. Touch fires on every
+// authenticated request, so persisting it would grow the event store with
+// request volume rather than with session count. Session.Touched stays an
+// in-memory signal; last-accessed lives in the projection.
+func (s *DefaultAuthenticationService) commitSessionEvents(ctx context.Context, session *entities.AuthSession) error {
+	if s.eventStore == nil {
+		return nil
+	}
+	uow := esApplication.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
+	if err := uow.Track(session); err != nil {
+		return fmt.Errorf("failed to track session: %w", err)
+	}
+	if err := uow.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit session events: %w", err)
+	}
+	return nil
 }
 
 // ScopeSessionToAccount re-scopes a stored session to another account the
@@ -504,6 +529,9 @@ func (s *DefaultAuthenticationService) ScopeSessionToAccount(ctx context.Context
 
 	if err = session.ScopeToAccount(accountID); err != nil {
 		return fmt.Errorf("failed to scope session to account: %w", err)
+	}
+	if err = s.commitSessionEvents(ctx, session); err != nil {
+		return err
 	}
 	if err = s.sessions.Save(ctx, session); err != nil {
 		return fmt.Errorf("failed to save session: %w", err)
@@ -762,6 +790,9 @@ func (s *DefaultAuthenticationService) RevokeSession(ctx context.Context, sessio
 		return fmt.Errorf("failed to revoke session: %w", revokeErr)
 	}
 
+	if commitErr := s.commitSessionEvents(ctx, session); commitErr != nil {
+		return commitErr
+	}
 	return s.sessions.Save(ctx, session)
 }
 

--- a/pkg/auth/application/authentication_service_test.go
+++ b/pkg/auth/application/authentication_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	"github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	authjwt "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/jwt"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/models"
 	esDomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	esInfra "github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
 )
@@ -2676,5 +2677,144 @@ func TestIssueIdentityToken_VouchedAccountSkipsTheReRead(t *testing.T) {
 
 	if _, err := svc.IssueIdentityToken(ctx, agent, "acct-1", application.AccountAlreadyVerified()); err != nil {
 		t.Fatalf("vouched IssueIdentityToken() error: %v", err)
+	}
+}
+
+// --- Session events are persisted (#73) ---
+
+func newServiceWithSessionEvents(t *testing.T) (*application.DefaultAuthenticationService, *testDeps, *esInfra.MemoryStore) {
+	t.Helper()
+	deps := &testDeps{
+		providers:   application.OAuthProviderRegistry{},
+		agents:      newMockAgentRepo(),
+		credentials: newMockCredentialRepo(),
+		sessions:    newMockSessionRepo(),
+		accounts:    newMockAccountRepo(),
+		tokens:      newMockTokenStore(),
+		authz:       &mockAuthorizationChecker{},
+	}
+	store := esInfra.NewMemoryStore()
+	svc := application.NewDefaultAuthenticationService(
+		deps.providers, deps.agents, deps.credentials, deps.sessions, deps.accounts,
+		application.WithTokenStore(deps.tokens),
+		application.WithEventStore(store),
+	)
+	return svc, deps, store
+}
+
+// The authentication timeline — created, re-scoped, revoked — is now durable
+// like every other aggregate's, so ApplyEvent stops being dead code.
+func TestDefaultAuthenticationService_SessionLifecycleIsPersisted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps, store := newServiceWithSessionEvents(t)
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	deps.accounts.accounts["acct-2"] = newScopedAccount(t, "acct-2", "Acme", entities.AccountTypeOrganization, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+	deps.accounts.memberRoles["acct-2:agent-1"] = entities.RoleMember
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	if err := svc.ScopeSessionToAccount(ctx, session.GetID(), "acct-2"); err != nil {
+		t.Fatalf("ScopeSessionToAccount() error: %v", err)
+	}
+	if err := svc.RevokeSession(ctx, session.GetID()); err != nil {
+		t.Fatalf("RevokeSession() error: %v", err)
+	}
+
+	events, err := store.GetEvents(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("GetEvents() error: %v", err)
+	}
+	var types []string
+	for _, e := range events {
+		types = append(types, e.EventType)
+	}
+	want := []string{
+		entities.EventTypeSessionCreated,
+		entities.EventTypeSessionAccountScoped,
+		entities.EventTypeSessionRevoked,
+	}
+	if len(types) != len(want) {
+		t.Fatalf("event types = %v, want %v", types, want)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Errorf("event %d = %q, want %q", i, types[i], want[i])
+		}
+	}
+}
+
+// Touch fires on every authenticated request. Persisting it would grow the
+// event store with request volume rather than with session count.
+func TestDefaultAuthenticationService_TouchIsNotPersisted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps, store := newServiceWithSessionEvents(t)
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	for range 3 {
+		if _, err := svc.ValidateSession(ctx, session.GetID()); err != nil {
+			t.Fatalf("ValidateSession() error: %v", err)
+		}
+	}
+
+	events, err := store.GetEvents(ctx, session.GetID())
+	if err != nil {
+		t.Fatalf("GetEvents() error: %v", err)
+	}
+	for _, e := range events {
+		if e.EventType == entities.EventTypeSessionTouched {
+			t.Fatalf("Session.Touched was persisted; events = %d", len(events))
+		}
+	}
+	if len(events) != 1 {
+		t.Errorf("event count = %d, want 1 (creation only)", len(events))
+	}
+}
+
+// A session restored from its projection must carry its version, or the next
+// commit fails its optimistic concurrency check.
+func TestDefaultAuthenticationService_RestoredSessionCanCommitAgain(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, deps, store := newServiceWithSessionEvents(t)
+	deps.accounts.accounts["acct-1"] = newScopedAccount(t, "acct-1", "Personal", entities.AccountTypePersonal, true)
+	deps.accounts.memberRoles["acct-1:agent-1"] = entities.RoleOwner
+
+	session, err := svc.CreateSession(ctx, "agent-1", "acct-1", "cred-1", "1.2.3.4", "UA", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	// Round-trip through the projection, as the repository does.
+	model := models.AuthSessionModelFromEntity(session)
+	restored, err := model.ToEntity()
+	if err != nil {
+		t.Fatalf("ToEntity() error: %v", err)
+	}
+	if restored.GetSequenceNo() != session.GetSequenceNo() {
+		t.Fatalf("restored sequence = %d, want %d", restored.GetSequenceNo(), session.GetSequenceNo())
+	}
+	deps.sessions.sessions[session.GetID()] = restored
+
+	if err := svc.RevokeSession(ctx, session.GetID()); err != nil {
+		t.Fatalf("RevokeSession() on a restored session: %v", err)
+	}
+	events, _ := store.GetEvents(ctx, session.GetID())
+	if len(events) != 2 {
+		t.Errorf("event count = %d, want 2", len(events))
 	}
 }

--- a/pkg/auth/domain/entities/auth_session.go
+++ b/pkg/auth/domain/entities/auth_session.go
@@ -105,14 +105,19 @@ func (s *AuthSession) UserAgent() string {
 }
 
 // Restore restores an AuthSession from database values without recording events.
-func (s *AuthSession) Restore(id, agentID, accountID, credentialID, ipAddress, userAgent string, active bool, createdAt, expiresAt, lastAccessedAt time.Time) error {
+//
+// sequenceNo must be the aggregate's version in the event store, which the
+// projection carries. Restoring at 0 while the store already holds the
+// session's creation event would make the next commit fail its optimistic
+// concurrency check.
+func (s *AuthSession) Restore(id, agentID, accountID, credentialID, ipAddress, userAgent string, active bool, createdAt, expiresAt, lastAccessedAt time.Time, sequenceNo int) error {
 	if id == "" {
 		return fmt.Errorf("id cannot be empty")
 	}
 	if agentID == "" {
 		return fmt.Errorf("agent ID cannot be empty")
 	}
-	s.BaseEntity = ddd.NewBaseEntity(id)
+	s.BaseEntity = ddd.RestoreBaseEntity(id, sequenceNo)
 	s.agentID = agentID
 	s.accountID = accountID
 	s.credentialID = credentialID

--- a/pkg/auth/domain/entities/auth_session_test.go
+++ b/pkg/auth/domain/entities/auth_session_test.go
@@ -319,7 +319,7 @@ func TestAuthSession_Restore(t *testing.T) {
 			t.Parallel()
 			sess := &entities.AuthSession{}
 			now := time.Now()
-			err := sess.Restore(tt.id, tt.agentID, "account-1", "cred-1", "192.168.1.1", "Mozilla/5.0", true, now, now.Add(24*time.Hour), now)
+			err := sess.Restore(tt.id, tt.agentID, "account-1", "cred-1", "192.168.1.1", "Mozilla/5.0", true, now, now.Add(24*time.Hour), now, 0)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -365,7 +365,7 @@ func TestAuthSession_ApplyEvent(t *testing.T) {
 
 	// Reconstruct from events
 	restored := &entities.AuthSession{}
-	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", false, time.Time{}, time.Time{}, time.Time{}); err != nil {
+	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", false, time.Time{}, time.Time{}, time.Time{}, 0); err != nil {
 		t.Fatalf("Restore() error: %v", err)
 	}
 
@@ -401,7 +401,7 @@ func TestAuthSession_ApplyEvent_Revoked(t *testing.T) {
 
 	// Reconstruct
 	restored := &entities.AuthSession{}
-	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", true, time.Time{}, time.Time{}, time.Time{}); err != nil {
+	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", true, time.Time{}, time.Time{}, time.Time{}, 0); err != nil {
 		t.Fatalf("Restore() error: %v", err)
 	}
 
@@ -434,7 +434,7 @@ func TestAuthSession_ApplyEvent_AccountScoped(t *testing.T) {
 
 	// Reconstruct
 	restored := &entities.AuthSession{}
-	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", true, time.Time{}, time.Time{}, time.Time{}); err != nil {
+	if err := restored.Restore("sess-1", "placeholder", "", "", "", "", true, time.Time{}, time.Time{}, time.Time{}, 0); err != nil {
 		t.Fatalf("Restore() error: %v", err)
 	}
 

--- a/pkg/auth/infrastructure/models/auth_session.go
+++ b/pkg/auth/infrastructure/models/auth_session.go
@@ -18,6 +18,9 @@ type AuthSessionModel struct {
 	LastAccessedAt time.Time
 	IPAddress      string
 	UserAgent      string
+	// SequenceNo is the aggregate version in the event store, so a restored
+	// session can commit further events without a concurrency conflict.
+	SequenceNo int
 }
 
 func (AuthSessionModel) TableName() string {
@@ -30,7 +33,7 @@ func (m *AuthSessionModel) ToEntity() (*entities.AuthSession, error) {
 	err := e.Restore(
 		m.ID, m.AgentID, m.AccountID, m.CredentialID,
 		m.IPAddress, m.UserAgent, m.Active,
-		m.CreatedAt, m.ExpiresAt, m.LastAccessedAt,
+		m.CreatedAt, m.ExpiresAt, m.LastAccessedAt, m.SequenceNo,
 	)
 	if err != nil {
 		return nil, err
@@ -51,5 +54,6 @@ func AuthSessionModelFromEntity(e *entities.AuthSession) *AuthSessionModel {
 		LastAccessedAt: e.LastAccessedAt(),
 		IPAddress:      e.IPAddress(),
 		UserAgent:      e.UserAgent(),
+		SequenceNo:     e.GetSequenceNo(),
 	}
 }


### PR DESCRIPTION
Closes #73

**Layer 3 of 3** — stack #78. Base: `fix/72-trust-just-verified-account` (#76).

`AuthSession` recorded four event types and discarded every one. Nothing appended them to a store, nothing replayed them, no subscriber consumed them — unlike `Agent`, `Account`, `Credential` and `Invite`, which all commit through a unit of work. `ApplyEvent`'s session branches were dead code in production, and `Session.AccountScoped` named a session-to-account edge no projection could ever see.

That mattered more after #68: the account only survives a rebuild *because* `ApplyEvent` handles it, and nothing in production ever performed that rebuild.

## What changed

`CreateSession`, `ScopeSessionToAccount` and `RevokeSession` commit through `SimpleUnitOfWork`, giving authentication a durable timeline: created, re-scoped, revoked.

`Touch` is deliberately excluded. It fires on **every authenticated request**, so persisting it would grow the event store with request volume rather than with session count. Last-accessed stays in the projection.

## The restore gap this uncovered

Persisting more than the creation event did not work at first. `AuthSession.Restore` called `NewBaseEntity`, which resets the version to 0, so a session hydrated from its projection claimed version 0 while the store already held its creation event — and the next commit failed its optimistic concurrency check.

The projection now carries the sequence number and `Restore` uses `RestoreBaseEntity`. Without this the change would have persisted **creation only**: a partial fix that looks complete until something re-scopes a session.

> Worth knowing: every other auth aggregate's `Restore` also calls `NewBaseEntity`, so the same latent gap exists for any aggregate that commits twice across a projection reload. Out of scope here, but it is not session-specific.

## Testing

The acceptance suite now runs against a **real event store**, so the rebuild-from-events scenario reads events back from storage instead of from the aggregate that produced them — a genuine round-trip rather than proof that `ApplyEvent` mirrors `RecordEvent`.

Three unit tests: the full lifecycle lands in the store in order, `Touch` never does, and a projection-restored session can commit again.

## Breaking change

`AuthSession.Restore` takes a trailing `sequenceNo`, and `auth_sessions` gains a `sequence_no` column. AutoMigrate adds it; existing rows correctly default to 0, having no stored events.
