### PR TITLE
ci(release): read the Go version from go.mod, and fix the release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          # Read the version from go.mod rather than pinning a literal. A
+          # literal drifted to 1.21 while the module moved to 1.25, and Go's
+          # toolchain switch covered for it well enough to build while leaving
+          # `go tool covdata` unresolvable — so `-coverprofile` failed for the
+          # two packages that have no test files, with no FAIL line to show
+          # for it. Every release since v1.0.0-beta.1 failed that way.
+          go-version-file: go.mod
       
       - name: Verify module
         run: |
@@ -40,31 +46,40 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
+          # Semver treats anything with a hyphen as a pre-release. Every tag so
+          # far is one (-beta.N), and marking those as a full release would
+          # make "latest" point at a beta.
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Version: $VERSION (prerelease: $([[ "$VERSION" == *-* ]] && echo true || echo false))"
+
+      - name: Build release notes from the tag annotation
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          # The annotated tag is where this project's release notes are
+          # written, so use them rather than restating a summary here.
+          {
+            git tag -l --format='%(contents:body)' "$VERSION"
+            echo
+            echo "### Installation"
+            echo
+            echo '```bash'
+            echo "go get github.com/akeemphilbert/pericarp@$VERSION"
+            echo '```'
+            echo
+            echo "[pkg.go.dev](https://pkg.go.dev/github.com/akeemphilbert/pericarp@$VERSION)"
+          } > "$RUNNER_TEMP/release-notes.md"
       
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ steps.version.outputs.version }}
-          body: |
-            ## Pericarp ${{ steps.version.outputs.version }}
-            
-            ### Installation
-            
-            ```bash
-            go get github.com/akeemphilbert/pericarp@${{ steps.version.outputs.version }}
-            ```
-            
-            ### Documentation
-            
-            - [pkg.go.dev](https://pkg.go.dev/github.com/akeemphilbert/pericarp@${{ steps.version.outputs.version }})
-            - [GitHub Repository](https://github.com/akeemphilbert/pericarp)
-            
-            ### Changes
-            
-            See [CHANGELOG.md](https://github.com/akeemphilbert/pericarp/blob/${{ steps.version.outputs.version }}/CHANGELOG.md) for details.
+          body_path: ${{ runner.temp }}/release-notes.md
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The `Release` workflow has failed on **every tag since `v1.0.0-beta.1`**. It has never once succeeded.

## Root cause

`setup-go` pinned a literal `go-version: '1.21'` while `go.mod` moved on to `1.25`. Go's toolchain switching downloaded 1.25 and built happily — which is exactly why this looked healthy — but it left `go tool covdata` unresolvable:

```
# github.com/akeemphilbert/pericarp/examples/projection
go: no such tool "covdata"
# github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/models
go: no such tool "covdata"
```

`covdata` is what `-coverprofile` uses to post-process packages that have **no test files**. This module has exactly two, and they are exactly the two that failed.

## Why it was invisible

Those two packages print **no `ok`, no `?`, and no `FAIL`**. So a 6,000-line `-v` log ran every other package green, ended on a clean `ok`, and then exited 1 with nothing anywhere to explain it. The tool error sits near the top, above thousands of lines of passing test output.

I confirmed it is deterministic by re-running the job, and confirmed the code is fine by running the identical command locally:

| | Go | Scope | Result |
|---|---|---|---|
| `ci.yml` | `1.25` | `./pkg/...` | pass |
| `release.yml` | `1.21` → downloads 1.25 | `./...` | **fail** |
| local | 1.25 | `./...` | pass (exit 0) |

Local and CI produce identical result lines — 20 `ok`, 1 `?`, 0 `FAIL`. Only the toolchain differs. CI never caught this because it runs on 1.25.

## Changes

**1. Read the Go version from `go.mod`.** A literal is what drifted in the first place; `go-version-file` cannot drift again when the language version moves.

**2. `prerelease` is derived from the tag.** Every tag so far is a semver pre-release (`-beta.N`), but the release was hard-coded `prerelease: false`. The first successful run would have published a beta as a full release and pointed **“latest” at it**.

**3. The release body no longer 404s.** It linked to `CHANGELOG.md`, which does not exist in this repository — every release would have shipped a dead link. The body now comes from the **annotated tag**, which is where this project's release notes are actually written, with the install snippet appended.

**4. `action-gh-release` v1 → v2.**

Defects 2 and 3 were unreachable until now, because the job never got past the test step. Fixing only the Go version would have exposed them on the very next tag.

## Verification

The workflow only triggers on tag pushes, so this cannot be proven by CI on this PR. What I did verify:

- Extracted the release-notes script and ran it against the real `v1.0.0-beta.5` tag: produces 67 lines of genuine notes plus a correctly fenced install block.
- Checked the `prerelease` derivation against `v1.0.0-beta.5` → `true`, `v1.0.0` → `false`, `v2.1.3-rc.1` → `true`.

**To prove it end to end:** after merging, delete and re-push `v1.0.0-beta.5`. That re-triggers the workflow without minting a new version.

## Not addressed here

`actions/checkout@v4` and `actions/setup-go@v5` are on the deprecated Node 20. It is a warning, not a failure, and bumping action majors is a separate change with its own risk.
